### PR TITLE
Fix DNS Changes Not Applying to Correct Network Interface

### DIFF
--- a/Sources/PingBarApp.swift
+++ b/Sources/PingBarApp.swift
@@ -73,7 +73,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
             case .good, .warning:
                 self.updateStatusIndicator(status)
                 if self.dnsRevertedForOutage, restoreDNS, let custom = self.customDNSBeforeCaptive, custom != "Empty" {
-                    if let iface = NetworkUtilities.defaultInterface, let service = NetworkUtilities.networkServiceName(for: iface) {
+                    if let iface = NetworkUtilities.defaultInterface(), let service = NetworkUtilities.networkServiceName(for: iface) {
                         _ = DNSManager.setDNSWithOsascript(service: service, dnsArg: custom)
                         self.dnsRevertedForOutage = false
                         self.customDNSBeforeCaptive = nil
@@ -84,7 +84,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
             case .bad:
                 self.updateStatusIndicator(.bad)
                 if revertDNS, !self.dnsRevertedForOutage {
-                    if let iface = NetworkUtilities.defaultInterface, let service = NetworkUtilities.networkServiceName(for: iface) {
+                    if let iface = NetworkUtilities.defaultInterface(), let service = NetworkUtilities.networkServiceName(for: iface) {
                         let lastCustom = UserDefaults.standard.string(forKey: "LastCustomDNS")
                         self.customDNSBeforeCaptive = (lastCustom != "Empty") ? lastCustom : nil
                         _ = DNSManager.setDNSWithOsascript(service: service, dnsArg: "Empty")
@@ -228,7 +228,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
     @MainActor
     @objc private func setDNS(_ sender: NSMenuItem) {
         guard let ip = sender.representedObject as? String? else { return }
-        guard let iface = NetworkUtilities.defaultInterface, let service = NetworkUtilities.networkServiceName(for: iface) else { return }
+        guard let iface = NetworkUtilities.defaultInterface(), let service = NetworkUtilities.networkServiceName(for: iface) else { return }
         let dnsArg = ip ?? "Empty"
         if dnsArg != "Empty" {
             UserDefaults.standard.set(dnsArg, forKey: "LastCustomDNS")


### PR DESCRIPTION
### Problem

The app previously determined the default network interface by selecting the first active one from `getifaddrs`, which often resulted in the Wi-Fi interface being selected — even when Ethernet was the actual route used by the system. Additionally, `networkServiceName(for:)` relied on `-listallhardwareports`, which failed when interface names were reused or renamed (e.g., "Thunderbolt Ethernet Slot 2").

As a result, DNS settings were incorrectly applied to the wrong service, or failed silently if the resolved service name was invalid.

### Solution

This PR updates both the interface detection and network service resolution mechanisms:

#### `NetworkUtilities.swift`
- `defaultInterface()` now uses `netstat -rn` to reliably identify the system’s current default route interface.
- `networkServiceName(for:)` now parses the output of `networksetup -listnetworkserviceorder`, ensuring the exact service name is retrieved for a given device (e.g., en6 → "Thunderbolt Ethernet Slot 2").
- Legacy IPv6 filtering and route detection code has been simplified.

#### `PingBarApp.swift`
- Updates all usage of `NetworkUtilities.defaultInterface` to the new method-style `NetworkUtilities.defaultInterface()`.
- Ensures DNS settings are now applied to the correct network service, even when interfaces are renamed or reused.
- Fixes the long-standing bug where users with USB docks or multi-port adapters could not correctly change DNS.

### Result

- DNS now reliably updates for the real default interface.
- Works as expected when both Wi-Fi and wired are connected.
- Fixes DNS errors like:
  > `execution error: Thunderbolt Ethernet Slot 0 is not a recognized network service.`

Tested on macOS with both wireless and multiple wired interfaces active.

