### PR TITLE
Add packet loss monitoring and dual-state tray icon

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,10 @@ let package = Package(
                 "NetworkUtilities.swift",
                 "PreferencesWindowController.swift",
                 "LaunchAgentManager.swift",
-                "SparklineRenderer.swift"
+                "SparklineRenderer.swift",
+                "UserDefaultsKeys.swift",
+                "LossTracker.swift",
+                "StatusIconRenderer.swift"
             ],
             sources: ["main.swift"]
         ),

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![macOS](https://img.shields.io/badge/macOS-12.0+-green.svg)](https://www.apple.com/macos/)
 [![Swift](https://img.shields.io/badge/Swift-6.1-orange.svg)](https://swift.org)
 
-PingBar is a lightweight, modern, non-intrusive, native macOS menu bar app that continuously monitors your network connectivity and DNS settings.
+PingBar is a lightweight, modern, non-intrusive, native macOS menu bar app that continuously monitors network latency, packet loss, and DNS settings.
 
-It provides real-time ping statistics, network interface information, and **one-click DNS management including dnscrypt-proxy control**, all from your menu bar with minimal system resource usage.
+It provides real-time ping statistics, packet loss monitoring, network interface information, and **one-click DNS management including dnscrypt-proxy control**, all from your menu bar with minimal system resource usage.
 
 ## Screenshots
 
@@ -16,8 +16,9 @@ It provides real-time ping statistics, network interface information, and **one-
 
 The main menu shows real-time network status with:
 
-- Current ping time and status (🟢 for good connectivity)
+- Current ping time and status
 - Sparkline graph with ping statistics (avg/min/max)
+- Packet loss percentage and collection progress
 - Active network interfaces with IP addresses
 - Current DNS resolver information
 - Quick access to DNS management and preferences
@@ -29,18 +30,21 @@ The main menu shows real-time network status with:
 The preferences window allows you to configure:
 - Ping interval and target host
 - High ping threshold for warnings
+- Passive or active packet loss measurement
+- Packet loss thresholds, window size, and active probe cadence
 - DNS auto-revert behavior for captive portals
 - Launch at login option
 
 ## Features
 
-- **Live Network Status**: Pings a configurable host (default: Google) and shows status with colored icons (🟢/🟡/🔴/🟠) in the menu bar.
+- **Live Network Status**: Pings a configurable host (default: Google) and shows latency and packet loss together in a single menu bar icon.
+- **Packet Loss Monitoring**: Measures loss passively from the regular ping stream or actively with configurable burst probes.
 - **Historical Ping Graph**: Unicode sparkline graph and statistics (avg/min/max) for recent pings.
 - **Network Interface Info**: Displays active local IP addresses with interface names.
 - **DNS Resolver Display**: Shows current DNS resolvers for your default interface.
 - **DNS Management**: Change DNS for your default interface with one click (System Default, Cloudflare, Google, Quad9, 114DNS, dnscrypt-proxy, etc.). **Perfect for controlling dnscrypt-proxy usage from the menu bar.**
 - **Captive Portal Detection**: Detects captive portals and can auto-revert DNS to default, restoring your custom DNS after login.
-- **Preferences Dialog**: Configure ping interval, target host, high ping threshold, DNS auto-revert, and launch at login.
+- **Preferences Dialog**: Configure ping interval, target host, high ping threshold, packet loss mode, packet loss thresholds, DNS auto-revert, and launch at login.
 - **Auto-Start**: Optionally launch PingBar at login using a LaunchAgent.
 - **Lightweight & Native**: Built with Swift, AppKit, and SwiftPM. No Python or Electron, no bloat. Minimal memory footprint.
 
@@ -129,7 +133,7 @@ swift test
 ### Getting Started
 
 1. **Launch PingBar**: Double-click `PingBar.app` or run from the command line
-2. **Menu Bar Icon**: Look for the colored icon in your menu bar (🟢/🟡/🔴/🟠)
+2. **Menu Bar Icon**: Look for the ring icon in your menu bar. The center shows latency; the ring shows packet loss.
 3. **Click the Icon**: View network status, ping statistics, and current settings
 4. **Configure Settings**: Select "Preferences…" to customize behavior
 
@@ -137,6 +141,7 @@ swift test
 
 - **Network Status**: Current ping time and connection status
 - **Ping Graph**: Visual sparkline showing recent ping history with statistics
+- **Packet Loss**: Current packet loss percentage, mode, and collection progress
 - **Network Interfaces**: List of active network interfaces and their IP addresses
 - **DNS Servers**: Current DNS resolvers for your default interface
 - **DNS Management**: Quick access to change DNS settings
@@ -166,18 +171,39 @@ Access preferences via the menu bar icon → "Preferences…"
 | **Ping Interval**       | How often to ping the target (seconds)                   | 5.0                    |
 | **Target Host**         | URL or IP to ping                                        | https://www.google.com |
 | **High Ping Threshold** | Latency threshold for warning state (ms)                 | 200                    |
+| **Packet Loss Mode**    | Use the main ping stream (`Passive`) or active bursts (`Active`) for loss measurement | Passive |
+| **Active Probe Interval** | How often active packet loss bursts run (seconds)      | 30.0                   |
+| **Active Burst Size**   | Number of HEAD requests per active loss burst            | 5                      |
+| **Packet Loss Window**  | Number of recent results kept for packet loss            | 50                     |
+| **Loss Warning Threshold** | Packet loss percentage for yellow ring               | 3.0                    |
+| **Loss Bad Threshold**  | Packet loss percentage for red ring                      | 10.0                   |
 | **DNS Auto-Revert**     | Revert DNS to system default when network is unreachable | false                  |
 | **Restore Custom DNS**  | Restore custom DNS after captive portal login            | false                  |
 | **Launch at Login**     | Auto-start PingBar when you log in                       | false                  |
 
 ### Status Icons
 
-| Icon | Status         | Description                              |
-| ---- | -------------- | ---------------------------------------- |
-| 🟢    | Good           | Network is responsive (ping < threshold) |
-| 🟡    | Warning        | High latency (ping ≥ threshold)          |
-| 🔴    | Bad            | Network unreachable or failed            |
-| 🟠    | Captive Portal | Captive portal detected                  |
+PingBar now uses a combined icon instead of a single four-state dot:
+
+- **Center fill**: latency state
+- **Outer ring**: packet loss state
+
+| Element | State | Meaning |
+| ------- | ----- | ------- |
+| Center fill | Green → Yellow → Orange → Red | Increasing latency severity |
+| Center fill | Purple | Captive portal detected |
+| Center fill | Dark gray | Network unavailable |
+| Outer ring | Green | Packet loss below warning threshold |
+| Outer ring | Yellow | Packet loss above warning threshold |
+| Outer ring | Red | Packet loss above bad threshold |
+| Outer ring | Gray | Still collecting enough packet-loss samples |
+
+### Packet Loss Modes
+
+- **Passive**: Uses only the normal scheduled ping results. This adds no extra traffic.
+- **Active**: Runs additional HEAD request bursts to the same host for faster packet loss sampling.
+
+Captive portal detections are excluded from packet loss accounting.
 
 ### Captive Portal Handling
 
@@ -222,6 +248,8 @@ swift test --filter TestName
 
 - Use a reliable, fast target host for pinging
 - Set reasonable ping intervals (5-10 seconds recommended)
+- Use `Passive` packet loss mode if you want zero additional background traffic
+- Use `Active` mode only when you need faster or denser packet loss sampling; low intervals and high burst sizes can create substantial traffic
 - Enable launch at login for continuous monitoring
 
 ## Security

--- a/Sources/DNSManager.swift
+++ b/Sources/DNSManager.swift
@@ -17,7 +17,7 @@ struct DNSManager {
         }
 
         // Check if there's a custom DNS server configured
-        let customDNS = UserDefaults.standard.string(forKey: "CustomDNSServer") ?? ""
+        let customDNS = UserDefaults.standard.string(forKey: UserDefaultsKey.customDNSServer) ?? ""
         if !customDNS.isEmpty {
             // If the custom DNS contains a space, treat it as "IP Name" format
             let components = customDNS.components(separatedBy: " ")
@@ -38,7 +38,7 @@ struct DNSManager {
     }
 
     static func getCustomDNSIP() -> String? {
-        let customDNS = UserDefaults.standard.string(forKey: "CustomDNSServer") ?? ""
+        let customDNS = UserDefaults.standard.string(forKey: UserDefaultsKey.customDNSServer) ?? ""
         if customDNS.isEmpty {
             return nil
         }

--- a/Sources/LossTracker.swift
+++ b/Sources/LossTracker.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Pure in-memory packet loss calculator.
+/// Tracks a rolling window of success/failure results and computes loss percentage.
+/// Contains no networking or timer logic — all configuration is passed in explicitly.
+final class LossTracker {
+    enum LossLevel {
+        case good, warning, bad
+    }
+
+    struct Configuration {
+        var windowSize: Int
+        var warningThreshold: Double
+        var badThreshold: Double
+
+        static let `default` = Configuration(
+            windowSize: 50,
+            warningThreshold: 3.0,
+            badThreshold: 10.0
+        )
+
+        /// Returns a copy with values clamped to safe ranges.
+        func clamped() -> Configuration {
+            Configuration(
+                windowSize: max(10, min(windowSize, 500)),
+                warningThreshold: max(0.1, warningThreshold),
+                badThreshold: max(warningThreshold + 0.1, badThreshold)
+            )
+        }
+    }
+
+    private var window: [Bool] = []
+    private var config: Configuration
+
+    /// Current packet loss percentage (0.0–100.0).
+    private(set) var lossPercent: Double = 0.0
+
+    /// Current classified loss level.
+    private(set) var level: LossLevel = .good
+
+    /// Number of countable samples currently in the window.
+    var sampleCount: Int { window.count }
+
+    /// Whether enough samples have been collected for a meaningful reading.
+    var hasEnoughSamples: Bool { window.count >= 3 }
+
+    init(config: Configuration = .default) {
+        self.config = config.clamped()
+    }
+
+    /// Record a probe result.
+    /// - Parameters:
+    ///   - success: Whether the probe succeeded.
+    ///   - isCountable: If false, the result is ignored (e.g., captive portal detections).
+    func record(success: Bool, isCountable: Bool = true) {
+        guard isCountable else { return }
+
+        window.append(success)
+        if window.count > config.windowSize {
+            window.removeFirst(window.count - config.windowSize)
+        }
+        recalculate()
+    }
+
+    /// Update configuration. Trims the window if the new size is smaller.
+    func updateConfiguration(_ newConfig: Configuration) {
+        config = newConfig.clamped()
+        if window.count > config.windowSize {
+            window.removeFirst(window.count - config.windowSize)
+        }
+        recalculate()
+    }
+
+    /// Clear all history and reset to initial state.
+    func reset() {
+        window.removeAll()
+        lossPercent = 0.0
+        level = .good
+    }
+
+    // MARK: - Private
+
+    private func recalculate() {
+        guard !window.isEmpty else {
+            lossPercent = 0.0
+            level = .good
+            return
+        }
+
+        let failures = window.filter { !$0 }.count
+        lossPercent = (Double(failures) / Double(window.count)) * 100.0
+
+        if lossPercent >= config.badThreshold {
+            level = .bad
+        } else if lossPercent >= config.warningThreshold {
+            level = .warning
+        } else {
+            level = .good
+        }
+    }
+}

--- a/Sources/PingBarApp.swift
+++ b/Sources/PingBarApp.swift
@@ -7,12 +7,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
     private var statusItem: NSStatusItem?
     private var pingManager: PingManager!
     private var pingMenuItem: NSMenuItem?
+    private var packetLossMenuItem: NSMenuItem?
     private var preferencesWindow: PreferencesWindowController?
+    private var preferencesMenuItem: NSMenuItem?
     private var ipMenuItems: [NSMenuItem] = []
     private var dnsMenuItem: NSMenuItem?
     private var dnsRevertedForOutage = false
     private var customDNSBeforeCaptive: String?
     private var graphMenuItem: NSMenuItem?
+    private var latestLatencyMs: Int?
+    private var latestPingStatus: PingManager.PingStatus = .bad
 
     nonisolated public override init() {
         super.init()
@@ -22,7 +26,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
         pingManager = PingManager()
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         setupStatusButton()
-        updateStatusIndicator(.bad)
+        renderIcon()
 
         let menu = NSMenu()
         menu.delegate = self
@@ -34,6 +38,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
         let graphItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
         self.styleGraphMenuItem(graphItem)
         menu.addItem(graphItem)
+
+        let lossItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        self.styleGraphMenuItem(lossItem)
+        menu.addItem(lossItem)
 
         menu.addItem(.separator())
 
@@ -49,11 +57,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
         statusItem?.menu = menu
         self.pingMenuItem = pingItem
         self.graphMenuItem = graphItem
+        self.packetLossMenuItem = lossItem
+        self.preferencesMenuItem = prefsItem
+        self.graphMenuItem?.isHidden = true
+        self.packetLossMenuItem?.isHidden = true
 
-        pingManager.onPingResult = { [weak self] status, result in
+        pingManager.onPingResult = { [weak self] result in
             guard let self else { return }
-            let revertDNS = UserDefaults.standard.bool(forKey: "RevertDNSOnCaptivePortal")
-            let restoreDNS = UserDefaults.standard.bool(forKey: "RestoreCustomDNSAfterCaptive")
+            let revertDNS = UserDefaults.standard.bool(forKey: UserDefaultsKey.revertDNSOnCaptivePortal)
+            let restoreDNS = UserDefaults.standard.bool(forKey: UserDefaultsKey.restoreCustomDNSAfterCaptive)
+            self.latestPingStatus = result.status
+            self.latestLatencyMs = result.latencyMs
             let pings = self.pingManager.recentPings
             if !pings.isEmpty {
                 let spark = SparklineRenderer.renderSparkline(pings: pings)
@@ -69,9 +83,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
                 self.graphMenuItem?.title = ""
                 self.graphMenuItem?.isHidden = true
             }
-            switch status {
+            switch result.status {
             case .good, .warning:
-                self.updateStatusIndicator(status)
                 if self.dnsRevertedForOutage, restoreDNS, let custom = self.customDNSBeforeCaptive, custom != "Empty" {
                     if let iface = NetworkUtilities.defaultInterface(), let service = NetworkUtilities.networkServiceName(for: iface) {
                         _ = DNSManager.setDNS(service: service, dnsArg: custom)
@@ -82,22 +95,28 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
                     self.dnsRevertedForOutage = false
                 }
             case .bad:
-                self.updateStatusIndicator(.bad)
                 if revertDNS, !self.dnsRevertedForOutage {
                     if let iface = NetworkUtilities.defaultInterface(), let service = NetworkUtilities.networkServiceName(for: iface) {
-                        let lastCustom = UserDefaults.standard.string(forKey: "LastCustomDNS")
+                        let lastCustom = UserDefaults.standard.string(forKey: UserDefaultsKey.lastCustomDNS)
                         self.customDNSBeforeCaptive = (lastCustom != "Empty") ? lastCustom : nil
                         _ = DNSManager.setDNS(service: service, dnsArg: "Empty")
                         self.dnsRevertedForOutage = true
                     }
                 }
             case .captivePortal:
-                self.updateStatusIndicator(.captivePortal)
+                break
             }
-            self.pingMenuItem?.title = result
+            self.pingMenuItem?.title = result.message
             if let pingItem = self.pingMenuItem {
                 self.stylePingMenuItem(pingItem)
             }
+            self.refreshPacketLossMenuItem()
+            self.renderIcon()
+        }
+        pingManager.onPacketLossUpdated = { [weak self] in
+            guard let self else { return }
+            self.refreshPacketLossMenuItem()
+            self.renderIcon()
         }
         pingManager.start()
 
@@ -109,19 +128,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
         ipMenuItems.forEach(menu.removeItem)
         ipMenuItems.removeAll()
         if let dnsMenu = dnsMenuItem { menu.removeItem(dnsMenu) }
-        if let graphItem = graphMenuItem, menu.items.contains(graphItem) { menu.removeItem(graphItem) }
-        var insertIndex = 0
-        if let pingItem = pingMenuItem, let pingIdx = menu.items.firstIndex(of: pingItem) {
-            insertIndex = pingIdx + 1
-        }
-        if let graphItem = graphMenuItem {
-            menu.insertItem(graphItem, at: insertIndex)
-            insertIndex += 1
-            let sep = NSMenuItem.separator()
-            menu.insertItem(sep, at: insertIndex)
-            ipMenuItems.append(sep)
-            insertIndex += 1
-        }
+        guard let preferencesMenuItem, let baseInsertIndex = menu.items.firstIndex(of: preferencesMenuItem) else { return }
+        var insertIndex = baseInsertIndex
         let ifaces = NetworkUtilities.localInterfaceAddresses()
         if !ifaces.isEmpty {
             for (idx, (iface, ip)) in ifaces.enumerated() {
@@ -193,17 +201,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
     @MainActor
     @objc private func showPreferences(_ sender: Any?) {
         if preferencesWindow == nil {
-            preferencesWindow = PreferencesWindowController { [weak self] host, interval, highPing, customDNS, revertDNS, restoreDNS, launchAtLogin in
-                UserDefaults.standard.set(interval, forKey: "PingInterval")
-                UserDefaults.standard.set(host, forKey: "PingHost")
-                UserDefaults.standard.set(highPing, forKey: "HighPingThreshold")
-                UserDefaults.standard.set(customDNS, forKey: "CustomDNSServer")
-                UserDefaults.standard.set(revertDNS, forKey: "RevertDNSOnCaptivePortal")
-                UserDefaults.standard.set(restoreDNS, forKey: "RestoreCustomDNSAfterCaptive")
-                UserDefaults.standard.set(launchAtLogin, forKey: "LaunchAtLogin")
-                self?.pingManager.updateSettings(host: host, interval: interval)
-                self?.pingManager.highPingThreshold = highPing
+            preferencesWindow = PreferencesWindowController { [weak self] in
+                self?.pingManager.reloadSettingsFromDefaults()
+                self?.refreshPacketLossMenuItem()
+                self?.renderIcon()
                 self?.preferencesWindow = nil
+                let launchAtLogin = UserDefaults.standard.bool(forKey: UserDefaultsKey.launchAtLogin)
                 LaunchAgentManager.setLaunchAtLogin(enabled: launchAtLogin)
             }
         }
@@ -232,9 +235,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
         guard let iface = NetworkUtilities.defaultInterface(), let service = NetworkUtilities.networkServiceName(for: iface) else { return }
         let dnsArg = ip ?? "Empty"
         if dnsArg != "Empty" {
-            UserDefaults.standard.set(dnsArg, forKey: "LastCustomDNS")
+            UserDefaults.standard.set(dnsArg, forKey: UserDefaultsKey.lastCustomDNS)
         } else {
-            UserDefaults.standard.removeObject(forKey: "LastCustomDNS")
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKey.lastCustomDNS)
         }
         let status = DNSManager.setDNS(service: service, dnsArg: dnsArg)
         if !status.success {
@@ -250,44 +253,49 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
     private func setupStatusButton() {
         guard let button = statusItem?.button else { return }
         button.font = NSFont.systemFont(ofSize: 16, weight: .medium)
-        button.imagePosition = .noImage
+        button.imagePosition = .imageOnly
     }
 
-    private func updateStatusIndicator(_ status: PingManager.PingStatus) {
+    private func renderIcon() {
         guard let button = statusItem?.button else { return }
+        button.attributedTitle = NSAttributedString(string: "")
+        button.image = StatusIconRenderer.render(
+            latencyMs: latestLatencyMs,
+            lossLevel: pingManager.lossTracker.level,
+            pingStatus: latestPingStatus,
+            hasEnoughLossSamples: pingManager.lossTracker.hasEnoughSamples
+        )
+        button.toolTip = tooltipText()
+    }
 
-        let attributes: [NSAttributedString.Key: Any]
-
-        switch status {
-        case .good:
-            attributes = [
-                .font: NSFont.systemFont(ofSize: 14, weight: .bold),
-                .foregroundColor: NSColor.systemGreen
-            ]
-            let attributedTitle = NSAttributedString(string: "●", attributes: attributes)
-            button.attributedTitle = attributedTitle
-        case .warning:
-            attributes = [
-                .font: NSFont.systemFont(ofSize: 14, weight: .bold),
-                .foregroundColor: NSColor.systemYellow
-            ]
-            let attributedTitle = NSAttributedString(string: "●", attributes: attributes)
-            button.attributedTitle = attributedTitle
-        case .bad:
-            attributes = [
-                .font: NSFont.systemFont(ofSize: 14, weight: .bold),
-                .foregroundColor: NSColor.systemRed
-            ]
-            let attributedTitle = NSAttributedString(string: "●", attributes: attributes)
-            button.attributedTitle = attributedTitle
-        case .captivePortal:
-            attributes = [
-                .font: NSFont.systemFont(ofSize: 14, weight: .bold),
-                .foregroundColor: NSColor.systemOrange
-            ]
-            let attributedTitle = NSAttributedString(string: "●", attributes: attributes)
-            button.attributedTitle = attributedTitle
+    private func tooltipText() -> String {
+        let pingText = latestLatencyMs.map { "\($0)ms" } ?? (latestPingStatus == .captivePortal ? "Captive Portal" : "Unavailable")
+        let lossText: String
+        if pingManager.lossTracker.hasEnoughSamples {
+            lossText = String(format: "%.1f%%", pingManager.lossTracker.lossPercent)
+        } else {
+            lossText = "Collecting"
         }
+        return "Ping: \(pingText) | Loss: \(lossText)"
+    }
+
+    private func refreshPacketLossMenuItem() {
+        guard let item = packetLossMenuItem else { return }
+        let sampleCount = pingManager.lossTracker.sampleCount
+        let windowSize = pingManager.packetLossWindowSize
+        let mode = pingManager.packetLossMode.displayName.lowercased()
+        if pingManager.lossTracker.hasEnoughSamples {
+            let lossText = String(format: "%.1f", pingManager.lossTracker.lossPercent)
+            item.title = "📉 Loss: \(lossText)% (\(mode), \(sampleCount)/\(windowSize))"
+            item.isHidden = false
+        } else if sampleCount > 0 {
+            item.title = "📉 Loss: collecting (\(mode), \(sampleCount)/\(windowSize))"
+            item.isHidden = false
+        } else {
+            item.title = ""
+            item.isHidden = true
+        }
+        styleGraphMenuItem(item)
     }
 
     private func stylePingMenuItem(_ item: NSMenuItem) {

--- a/Sources/PingManager.swift
+++ b/Sources/PingManager.swift
@@ -2,106 +2,147 @@ import Foundation
 
 @MainActor
 final class PingManager {
-    private var timer: Timer?
-    private var url: URL
-    private var interval: TimeInterval
-    private var lastPingFailedAt: Date?
-    var onPingResult: ((PingStatus, String) -> Void)?
-    var highPingThreshold: Int {
-        get { UserDefaults.standard.integer(forKey: "HighPingThreshold").nonZeroOr(200) }
-        set { UserDefaults.standard.set(newValue, forKey: "HighPingThreshold") }
-    }
     enum PingStatus {
         case good, warning, bad, captivePortal
     }
+
+    enum PacketLossMode: String {
+        case passive
+        case active
+
+        var displayName: String {
+            rawValue.capitalized
+        }
+    }
+
+    struct PingResult {
+        let status: PingStatus
+        let message: String
+        let latencyMs: Int?
+        let success: Bool
+        let countsAsLoss: Bool
+    }
+
+    private var timer: Timer?
+    private var activeBurstTimer: Timer?
+    private var currentPingTask: URLSessionDataTask?
+    private var activeBurstTasks: [URLSessionDataTask] = []
+    private var isActiveBurstInFlight = false
+    private var lifecycleGeneration = 0
+    private var isRunning = false
+    private var url: URL
+    private var interval: TimeInterval
+    private var lastPingFailedAt: Date?
+    private var latestMainStatus: PingStatus = .bad
+    private var packetLossProbeInterval: TimeInterval = 30.0
+    private var packetLossBurstSize: Int = 5
+    private(set) var packetLossWindowSize = 50
+    private var highPingThresholdValue = 200
+
+    var onPingResult: ((PingResult) -> Void)?
+    var onPacketLossUpdated: (() -> Void)?
+
+    var highPingThreshold: Int {
+        get { highPingThresholdValue }
+        set {
+            let clamped = max(1, newValue)
+            highPingThresholdValue = clamped
+            UserDefaults.standard.set(clamped, forKey: UserDefaultsKey.highPingThreshold)
+        }
+    }
+
+    private(set) var packetLossMode: PacketLossMode = .passive
     private(set) var recentPings: [Int] = []
+    private(set) var lossTracker = LossTracker()
     private let maxRecentPings = 30
 
     init() {
-        let host = UserDefaults.standard.string(forKey: "PingHost") ?? "https://www.google.com"
-        self.url = URL(string: host) ?? URL(string: "https://www.google.com")!
-        let intervalValue = UserDefaults.standard.double(forKey: "PingInterval")
-        self.interval = intervalValue > 0 ? intervalValue : 5.0
+        self.url = URL(string: "https://www.google.com")!
+        self.interval = 5.0
+        reloadSettingsFromDefaults(restartIfRunning: false)
     }
 
     func updateSettings(host: String, interval: TimeInterval) {
+        UserDefaults.standard.set(host, forKey: UserDefaultsKey.pingHost)
+        UserDefaults.standard.set(interval, forKey: UserDefaultsKey.pingInterval)
+        reloadSettingsFromDefaults()
+    }
+
+    func reloadSettingsFromDefaults(restartIfRunning: Bool = true) {
+        let defaults = UserDefaults.standard
+        let wasRunning = isRunning
+        let previousMode = packetLossMode
+
+        let host = defaults.string(forKey: UserDefaultsKey.pingHost) ?? "https://www.google.com"
         url = URL(string: host) ?? URL(string: "https://www.google.com")!
-        self.interval = interval
-        start()
+
+        let intervalValue = defaults.double(forKey: UserDefaultsKey.pingInterval)
+        interval = intervalValue > 0 ? intervalValue : 5.0
+
+        let threshold = defaults.integer(forKey: UserDefaultsKey.highPingThreshold).nonZeroOr(200)
+        highPingThresholdValue = max(1, threshold)
+
+        packetLossMode = PacketLossMode(rawValue: defaults.string(forKey: UserDefaultsKey.packetLossMode) ?? "") ?? .passive
+        packetLossWindowSize = clampValue(defaults.integer(forKey: UserDefaultsKey.packetLossWindowSize).nonZeroOr(50), min: 10, max: 500)
+        packetLossProbeInterval = max(1.0, defaults.double(forKey: UserDefaultsKey.packetLossProbeInterval).nonZeroOr(30.0))
+        packetLossBurstSize = clampValue(defaults.integer(forKey: UserDefaultsKey.packetLossBurstSize).nonZeroOr(5), min: 1, max: 100)
+
+        let warningThreshold = defaults.double(forKey: UserDefaultsKey.packetLossWarningThreshold).nonZeroOr(3.0)
+        let badThreshold = defaults.double(forKey: UserDefaultsKey.packetLossBadThreshold).nonZeroOr(10.0)
+        lossTracker.updateConfiguration(.init(
+            windowSize: packetLossWindowSize,
+            warningThreshold: warningThreshold,
+            badThreshold: badThreshold
+        ))
+
+        if previousMode != packetLossMode {
+            lossTracker.reset()
+            onPacketLossUpdated?()
+        }
+
+        if restartIfRunning, wasRunning {
+            start()
+        }
     }
 
     func start() {
         stop()
+        isRunning = true
+
         timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             guard let self else { return }
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 self.ping()
             }
         }
+
+        if packetLossMode == .active {
+            activeBurstTimer = Timer.scheduledTimer(withTimeInterval: packetLossProbeInterval, repeats: true) { [weak self] _ in
+                guard let self else { return }
+                Task { @MainActor in
+                    self.runActiveBurst()
+                }
+            }
+        }
+
         ping()
+        if packetLossMode == .active {
+            runActiveBurst()
+        }
     }
 
     func stop() {
+        lifecycleGeneration += 1
+        isRunning = false
         timer?.invalidate()
         timer = nil
-    }
-
-    private func ping() {
-        let start = Date()
-        var request = URLRequest(url: url)
-        request.httpMethod = "HEAD"
-        request.timeoutInterval = 3.0
-        let task = URLSession.shared.dataTask(with: request) { [weak self] _, _, error in
-            guard let self else { return }
-            DispatchQueue.main.async {
-                if error != nil {
-                    self.detectCaptivePortal { @Sendable [weak self] isCaptive in
-                        Task { @MainActor [weak self] in
-                            guard let self else { return }
-                            if isCaptive {
-                                self.onPingResult?(.captivePortal, "Captive Portal Detected")
-                            } else {
-                                if self.lastPingFailedAt == nil {
-                                    self.lastPingFailedAt = Date()
-                                }
-                                let downFor = Int(Date().timeIntervalSince(self.lastPingFailedAt ?? Date()))
-                                self.onPingResult?(.bad, "No Network (\(downFor)s)")
-                            }
-                        }
-                    }
-                } else {
-                    self.lastPingFailedAt = nil
-                    let ms = Int(Date().timeIntervalSince(start) * 1000)
-                    self.recentPings.append(ms)
-                    if self.recentPings.count > self.maxRecentPings {
-                        self.recentPings.removeFirst(self.recentPings.count - self.maxRecentPings)
-                    }
-                    let status: PingStatus = ms > self.highPingThreshold ? .warning : .good
-                    self.onPingResult?(status, "Ping: \(ms)ms")
-                }
-            }
-        }
-        task.resume()
-    }
-
-    private func detectCaptivePortal(completion: @escaping @Sendable (Bool) -> Void) {
-        guard let url = URL(string: "http://www.gstatic.com/generate_204") else {
-            completion(false)
-            return
-        }
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.timeoutInterval = 3.0
-        let task = URLSession.shared.dataTask(with: request) { _, response, _ in
-            Task { @MainActor in
-                if let http = response as? HTTPURLResponse {
-                    completion(http.statusCode != 204)
-                } else {
-                    completion(false)
-                }
-            }
-        }
-        task.resume()
+        activeBurstTimer?.invalidate()
+        activeBurstTimer = nil
+        currentPingTask?.cancel()
+        currentPingTask = nil
+        activeBurstTasks.forEach { $0.cancel() }
+        activeBurstTasks.removeAll()
+        isActiveBurstInFlight = false
     }
 
     var currentHost: String {
@@ -111,10 +152,192 @@ final class PingManager {
     func getRecentPings() -> [Int] {
         recentPings
     }
+
+    private func ping() {
+        let generation = lifecycleGeneration
+        let task = makeProbeTask(for: url, captureLatency: true) { [weak self] success, latencyMs in
+            guard let self else { return }
+            Task { @MainActor [weak self] in
+                guard let self, self.lifecycleGeneration == generation else { return }
+                self.currentPingTask = nil
+                if success {
+                    self.handleSuccessfulPing(latencyMs: latencyMs ?? 0)
+                } else {
+                    self.handleFailedPing(generation: generation)
+                }
+            }
+        }
+        currentPingTask = task
+        task.resume()
+    }
+
+    private func handleSuccessfulPing(latencyMs: Int) {
+        lastPingFailedAt = nil
+        latestMainStatus = latencyMs > highPingThresholdValue ? .warning : .good
+        recentPings.append(latencyMs)
+        if recentPings.count > maxRecentPings {
+            recentPings.removeFirst(recentPings.count - maxRecentPings)
+        }
+
+        let result = PingResult(
+            status: latestMainStatus,
+            message: "Ping: \(latencyMs)ms",
+            latencyMs: latencyMs,
+            success: true,
+            countsAsLoss: true
+        )
+        recordPassiveLossIfNeeded(result)
+        onPingResult?(result)
+    }
+
+    private func handleFailedPing(generation: Int) {
+        detectCaptivePortal { [weak self] isCaptive in
+            guard let self else { return }
+            Task { @MainActor [weak self] in
+                guard let self, self.lifecycleGeneration == generation else { return }
+                if isCaptive {
+                    self.latestMainStatus = .captivePortal
+                    let result = PingResult(
+                        status: .captivePortal,
+                        message: "Captive Portal Detected",
+                        latencyMs: nil,
+                        success: false,
+                        countsAsLoss: false
+                    )
+                    self.recordPassiveLossIfNeeded(result)
+                    self.onPingResult?(result)
+                } else {
+                    self.latestMainStatus = .bad
+                    if self.lastPingFailedAt == nil {
+                        self.lastPingFailedAt = Date()
+                    }
+                    let downFor = Int(Date().timeIntervalSince(self.lastPingFailedAt ?? Date()))
+                    let result = PingResult(
+                        status: .bad,
+                        message: "No Network (\(downFor)s)",
+                        latencyMs: nil,
+                        success: false,
+                        countsAsLoss: true
+                    )
+                    self.recordPassiveLossIfNeeded(result)
+                    self.onPingResult?(result)
+                }
+            }
+        }
+    }
+
+    private func recordPassiveLossIfNeeded(_ result: PingResult) {
+        guard packetLossMode == .passive else { return }
+        lossTracker.record(success: result.success, isCountable: result.countsAsLoss)
+    }
+
+    private func runActiveBurst() {
+        guard packetLossMode == .active else { return }
+        guard latestMainStatus != .captivePortal else { return }
+        guard !isActiveBurstInFlight else { return }
+
+        let generation = lifecycleGeneration
+        isActiveBurstInFlight = true
+        activeBurstTasks.removeAll()
+
+        let group = DispatchGroup()
+        let counter = BurstCounter()
+
+        for _ in 0..<packetLossBurstSize {
+            group.enter()
+            let task = makeProbeTask(for: url, captureLatency: false) { success, _ in
+                counter.record(success: success)
+                group.leave()
+            }
+            activeBurstTasks.append(task)
+            task.resume()
+        }
+
+        group.notify(queue: .main) { [weak self] in
+            guard let self, self.lifecycleGeneration == generation else { return }
+            self.activeBurstTasks.removeAll()
+            self.isActiveBurstInFlight = false
+            guard self.packetLossMode == .active, self.latestMainStatus != .captivePortal else { return }
+            let summary = counter.snapshot()
+            for _ in 0..<summary.successes {
+                self.lossTracker.record(success: true)
+            }
+            for _ in 0..<summary.failures {
+                self.lossTracker.record(success: false)
+            }
+            self.onPacketLossUpdated?()
+        }
+    }
+
+    private func makeProbeTask(
+        for targetURL: URL,
+        captureLatency: Bool,
+        completion: @escaping @Sendable (Bool, Int?) -> Void
+    ) -> URLSessionDataTask {
+        let start = captureLatency ? Date() : nil
+        var request = URLRequest(url: targetURL)
+        request.httpMethod = "HEAD"
+        request.timeoutInterval = 3.0
+        return URLSession.shared.dataTask(with: request) { _, _, error in
+            let latencyMs = start.map { Int(Date().timeIntervalSince($0) * 1000) }
+            completion(error == nil, error == nil ? latencyMs : nil)
+        }
+    }
+
+    private func detectCaptivePortal(completion: @escaping @Sendable (Bool) -> Void) {
+        guard let captiveURL = URL(string: "http://www.gstatic.com/generate_204") else {
+            completion(false)
+            return
+        }
+        var request = URLRequest(url: captiveURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 3.0
+        let task = URLSession.shared.dataTask(with: request) { _, response, _ in
+            if let http = response as? HTTPURLResponse {
+                completion(http.statusCode != 204)
+            } else {
+                completion(false)
+            }
+        }
+        task.resume()
+    }
 }
 
-private extension Int {
-    func nonZeroOr(_ fallback: Int) -> Int {
-        self > 0 ? self : fallback
+private final class BurstCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var successes = 0
+    private var failures = 0
+
+    func record(success: Bool) {
+        lock.lock()
+        if success {
+            successes += 1
+        } else {
+            failures += 1
+        }
+        lock.unlock()
     }
+
+    func snapshot() -> (successes: Int, failures: Int) {
+        lock.lock()
+        let result = (successes, failures)
+        lock.unlock()
+        return result
+    }
+}
+
+private extension BinaryInteger {
+    func nonZeroOr<T: BinaryInteger>(_ fallback: T) -> T {
+        self > 0 ? T(self) : fallback
+    }
+}
+
+private extension BinaryFloatingPoint {
+    func nonZeroOr<T: BinaryFloatingPoint>(_ fallback: T) -> T {
+        self > 0 ? T(self) : fallback
+    }
+}
+
+private func clampValue<T: Comparable>(_ value: T, min minValue: T, max maxValue: T) -> T {
+    Swift.max(minValue, Swift.min(value, maxValue))
 }

--- a/Sources/PreferencesWindowController.swift
+++ b/Sources/PreferencesWindowController.swift
@@ -5,165 +5,143 @@ class PreferencesViewController: NSViewController {
     let hostField = NSTextField()
     let highPingField = NSTextField()
     let customDNSField = NSTextField()
+    let packetLossModePopup = NSPopUpButton()
+    let packetLossProbeIntervalField = NSTextField()
+    let packetLossBurstSizeField = NSTextField()
+    let packetLossWindowSizeField = NSTextField()
+    let packetLossWarningThresholdField = NSTextField()
+    let packetLossBadThresholdField = NSTextField()
     let revertDNSCheckbox = NSButton(checkboxWithTitle: "Revert DNS to System Default when network is unreachable", target: nil, action: nil)
     let restoreDNSCheckbox = NSButton(checkboxWithTitle: "Restore my custom DNS after passing captive portal", target: nil, action: nil)
     let launchAtLoginCheckbox = NSButton(checkboxWithTitle: "Launch PingBar at login", target: nil, action: nil)
-    var onSave: ((String, Double, Int, String, Bool, Bool, Bool) -> Void)?
+    var onSave: (() -> Void)?
 
     override func loadView() {
         let view = NSView()
         self.view = view
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.setFrameSize(NSSize(width: 480, height: 340))
-
-        // Set a nice background color
+        view.setFrameSize(NSSize(width: 520, height: 520))
         view.wantsLayer = true
         view.layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
 
-        // Header
         let headerLabel = NSTextField(labelWithString: "⚙️ PingBar Preferences")
         headerLabel.font = NSFont.systemFont(ofSize: 18, weight: .semibold)
         headerLabel.alignment = .center
         headerLabel.textColor = NSColor.labelColor
 
-        // Section headers
-        let networkSectionLabel = NSTextField(labelWithString: "🌐 Network Settings")
-        networkSectionLabel.font = NSFont.systemFont(ofSize: 14, weight: .medium)
-        networkSectionLabel.textColor = NSColor.secondaryLabelColor
+        let networkSectionLabel = sectionLabel("🌐 Network Settings")
+        let packetLossSectionLabel = sectionLabel("📉 Packet Loss")
+        let dnsSectionLabel = sectionLabel("🔧 DNS Management")
+        let systemSectionLabel = sectionLabel("💻 System Integration")
 
-        let dnsSectionLabel = NSTextField(labelWithString: "🔧 DNS Management")
-        dnsSectionLabel.font = NSFont.systemFont(ofSize: 14, weight: .medium)
-        dnsSectionLabel.textColor = NSColor.secondaryLabelColor
+        let intervalLabel = fieldLabel("⏱ Ping interval (seconds):")
+        let hostLabel = fieldLabel("🎯 Target host (URL):")
+        let highPingLabel = fieldLabel("⚠️ High ping threshold (ms):")
+        let customDNSLabel = fieldLabel("🔧 Custom DNS (optional):")
+        let packetLossModeLabel = fieldLabel("📊 Loss measurement mode:")
+        let packetLossProbeIntervalLabel = fieldLabel("⏱ Active probe interval (s):")
+        let packetLossBurstSizeLabel = fieldLabel("📦 Active burst size:")
+        let packetLossWindowSizeLabel = fieldLabel("🪟 Loss window size:")
+        let packetLossWarningThresholdLabel = fieldLabel("🟡 Warning threshold (%):")
+        let packetLossBadThresholdLabel = fieldLabel("🔴 Bad threshold (%):")
 
-        let systemSectionLabel = NSTextField(labelWithString: "💻 System Integration")
-        systemSectionLabel.font = NSFont.systemFont(ofSize: 14, weight: .medium)
-        systemSectionLabel.textColor = NSColor.secondaryLabelColor
-
-        // Labels
-        let intervalLabel = NSTextField(labelWithString: "⏱ Ping interval (seconds):")
-        let hostLabel = NSTextField(labelWithString: "🎯 Target host (URL):")
-        let highPingLabel = NSTextField(labelWithString: "⚠️ High ping threshold (ms):")
-        let customDNSLabel = NSTextField(labelWithString: "🔧 Custom DNS (optional):")
-        intervalLabel.alignment = .right
-        hostLabel.alignment = .right
-        highPingLabel.alignment = .right
-        customDNSLabel.alignment = .right
-        intervalLabel.font = NSFont.systemFont(ofSize: 13, weight: .medium)
-        hostLabel.font = NSFont.systemFont(ofSize: 13, weight: .medium)
-        highPingLabel.font = NSFont.systemFont(ofSize: 13, weight: .medium)
-        customDNSLabel.font = NSFont.systemFont(ofSize: 13, weight: .medium)
-        intervalLabel.textColor = NSColor.labelColor
-        hostLabel.textColor = NSColor.labelColor
-        highPingLabel.textColor = NSColor.labelColor
-        customDNSLabel.textColor = NSColor.labelColor
-
-        // Fields with enhanced styling
-        self.styleTextField(intervalField)
-        intervalField.stringValue = String(UserDefaults.standard.double(forKey: "PingInterval") > 0 ? UserDefaults.standard.double(forKey: "PingInterval") : 5.0)
+        styleTextField(intervalField)
+        intervalField.stringValue = String(defaultDouble(for: UserDefaultsKey.pingInterval, fallback: 5.0))
         intervalField.placeholderString = "e.g. 5"
 
-        self.styleTextField(hostField)
-        hostField.stringValue = UserDefaults.standard.string(forKey: "PingHost") ?? "https://www.google.com"
+        styleTextField(hostField)
+        hostField.stringValue = UserDefaults.standard.string(forKey: UserDefaultsKey.pingHost) ?? "https://www.google.com"
         hostField.placeholderString = "e.g. https://www.google.com"
 
-        self.styleTextField(highPingField)
-        highPingField.stringValue = String(UserDefaults.standard.integer(forKey: "HighPingThreshold") > 0 ? UserDefaults.standard.integer(forKey: "HighPingThreshold") : 200)
+        styleTextField(highPingField)
+        highPingField.stringValue = String(defaultInt(for: UserDefaultsKey.highPingThreshold, fallback: 200))
         highPingField.placeholderString = "e.g. 200"
 
-        self.styleTextField(customDNSField)
-        customDNSField.stringValue = UserDefaults.standard.string(forKey: "CustomDNSServer") ?? ""
+        styleTextField(customDNSField)
+        customDNSField.stringValue = UserDefaults.standard.string(forKey: UserDefaultsKey.customDNSServer) ?? ""
         customDNSField.placeholderString = "e.g. 1.1.1.1 or My Server"
 
-        // Styled checkboxes
-        self.styleCheckbox(revertDNSCheckbox)
-        self.styleCheckbox(restoreDNSCheckbox)
-        self.styleCheckbox(launchAtLoginCheckbox)
+        stylePopup(packetLossModePopup)
+        packetLossModePopup.addItems(withTitles: ["Passive", "Active"])
+        let savedMode = PingManager.PacketLossMode(rawValue: UserDefaults.standard.string(forKey: UserDefaultsKey.packetLossMode) ?? "") ?? .passive
+        packetLossModePopup.selectItem(withTitle: savedMode.displayName)
+        packetLossModePopup.target = self
+        packetLossModePopup.action = #selector(packetLossModeChanged)
 
-        // Enhanced buttons
+        styleTextField(packetLossProbeIntervalField)
+        packetLossProbeIntervalField.stringValue = String(defaultDouble(for: UserDefaultsKey.packetLossProbeInterval, fallback: 30.0))
+        packetLossProbeIntervalField.placeholderString = "e.g. 30"
+
+        styleTextField(packetLossBurstSizeField)
+        packetLossBurstSizeField.stringValue = String(defaultInt(for: UserDefaultsKey.packetLossBurstSize, fallback: 5))
+        packetLossBurstSizeField.placeholderString = "e.g. 5"
+
+        styleTextField(packetLossWindowSizeField)
+        packetLossWindowSizeField.stringValue = String(defaultInt(for: UserDefaultsKey.packetLossWindowSize, fallback: 50))
+        packetLossWindowSizeField.placeholderString = "e.g. 50"
+
+        styleTextField(packetLossWarningThresholdField)
+        packetLossWarningThresholdField.stringValue = String(defaultDouble(for: UserDefaultsKey.packetLossWarningThreshold, fallback: 3.0))
+        packetLossWarningThresholdField.placeholderString = "e.g. 3"
+
+        styleTextField(packetLossBadThresholdField)
+        packetLossBadThresholdField.stringValue = String(defaultDouble(for: UserDefaultsKey.packetLossBadThreshold, fallback: 10.0))
+        packetLossBadThresholdField.placeholderString = "e.g. 10"
+
+        styleCheckbox(revertDNSCheckbox)
+        styleCheckbox(restoreDNSCheckbox)
+        styleCheckbox(launchAtLoginCheckbox)
+
         let saveButton = NSButton(title: "💾 Save Settings", target: self, action: #selector(saveClicked))
         let cancelButton = NSButton(title: "❌ Cancel", target: self, action: #selector(cancelClicked))
-        self.styleButton(saveButton, isPrimary: true)
-        self.styleButton(cancelButton, isPrimary: false)
+        styleButton(saveButton, isPrimary: true)
+        styleButton(cancelButton, isPrimary: false)
         saveButton.setContentHuggingPriority(.required, for: .horizontal)
         cancelButton.setContentHuggingPriority(.required, for: .horizontal)
         saveButton.translatesAutoresizingMaskIntoConstraints = false
         cancelButton.translatesAutoresizingMaskIntoConstraints = false
 
-        // Create organized sections
-        let headerStack = NSStackView(views: [headerLabel])
-        headerStack.orientation = .vertical
-        headerStack.spacing = 20
-        headerStack.translatesAutoresizingMaskIntoConstraints = false
-
-        // Network settings section
-        let networkStack = NSStackView()
-        networkStack.orientation = .vertical
-        networkStack.spacing = 12
-        networkStack.translatesAutoresizingMaskIntoConstraints = false
-
-        let intervalRow = NSStackView(views: [intervalLabel, intervalField])
-        intervalRow.orientation = .horizontal
-        intervalRow.spacing = 12
-        intervalRow.alignment = .centerY
-
-        let hostRow = NSStackView(views: [hostLabel, hostField])
-        hostRow.orientation = .horizontal
-        hostRow.spacing = 12
-        hostRow.alignment = .centerY
-
-        let highPingRow = NSStackView(views: [highPingLabel, highPingField])
-        highPingRow.orientation = .horizontal
-        highPingRow.spacing = 12
-        highPingRow.alignment = .centerY
-
-        let customDNSRow = NSStackView(views: [customDNSLabel, customDNSField])
-        customDNSRow.orientation = .horizontal
-        customDNSRow.spacing = 12
-        customDNSRow.alignment = .centerY
-
+        let networkStack = verticalStack(spacing: 12)
         networkStack.addArrangedSubview(networkSectionLabel)
-        networkStack.addArrangedSubview(intervalRow)
-        networkStack.addArrangedSubview(hostRow)
-        networkStack.addArrangedSubview(highPingRow)
-        networkStack.addArrangedSubview(customDNSRow)
+        networkStack.addArrangedSubview(makeRow(label: intervalLabel, control: intervalField))
+        networkStack.addArrangedSubview(makeRow(label: hostLabel, control: hostField))
+        networkStack.addArrangedSubview(makeRow(label: highPingLabel, control: highPingField))
+        networkStack.addArrangedSubview(makeRow(label: customDNSLabel, control: customDNSField))
 
-        // DNS settings section
-        let dnsStack = NSStackView()
-        dnsStack.orientation = .vertical
-        dnsStack.spacing = 8
-        dnsStack.translatesAutoresizingMaskIntoConstraints = false
+        let packetLossStack = verticalStack(spacing: 12)
+        packetLossStack.addArrangedSubview(packetLossSectionLabel)
+        packetLossStack.addArrangedSubview(makeRow(label: packetLossModeLabel, control: packetLossModePopup))
+        packetLossStack.addArrangedSubview(makeRow(label: packetLossProbeIntervalLabel, control: packetLossProbeIntervalField))
+        packetLossStack.addArrangedSubview(makeRow(label: packetLossBurstSizeLabel, control: packetLossBurstSizeField))
+        packetLossStack.addArrangedSubview(makeRow(label: packetLossWindowSizeLabel, control: packetLossWindowSizeField))
+        packetLossStack.addArrangedSubview(makeRow(label: packetLossWarningThresholdLabel, control: packetLossWarningThresholdField))
+        packetLossStack.addArrangedSubview(makeRow(label: packetLossBadThresholdLabel, control: packetLossBadThresholdField))
+
+        let dnsStack = verticalStack(spacing: 8)
         dnsStack.addArrangedSubview(dnsSectionLabel)
         dnsStack.addArrangedSubview(revertDNSCheckbox)
         dnsStack.addArrangedSubview(restoreDNSCheckbox)
 
-        // System settings section
-        let systemStack = NSStackView()
-        systemStack.orientation = .vertical
-        systemStack.spacing = 8
-        systemStack.translatesAutoresizingMaskIntoConstraints = false
+        let systemStack = verticalStack(spacing: 8)
         systemStack.addArrangedSubview(systemSectionLabel)
         systemStack.addArrangedSubview(launchAtLoginCheckbox)
 
-        // Main form stack
-        let formStack = NSStackView()
-        formStack.orientation = .vertical
-        formStack.spacing = 20
-        formStack.translatesAutoresizingMaskIntoConstraints = false
+        let formStack = verticalStack(spacing: 20)
         formStack.addArrangedSubview(networkStack)
-        formStack.addArrangedSubview(self.createSeparator())
+        formStack.addArrangedSubview(createSeparator())
+        formStack.addArrangedSubview(packetLossStack)
+        formStack.addArrangedSubview(createSeparator())
         formStack.addArrangedSubview(dnsStack)
-        formStack.addArrangedSubview(self.createSeparator())
+        formStack.addArrangedSubview(createSeparator())
         formStack.addArrangedSubview(systemStack)
 
-        // Button stack
         let buttonStack = NSStackView(views: [saveButton, cancelButton])
         buttonStack.orientation = .horizontal
         buttonStack.spacing = 12
         buttonStack.alignment = .centerY
         buttonStack.translatesAutoresizingMaskIntoConstraints = false
 
-        // Main vertical stack with better spacing
-        let mainStack = NSStackView(views: [headerStack, formStack, buttonStack])
+        let mainStack = NSStackView(views: [headerLabel, formStack, buttonStack])
         mainStack.orientation = .vertical
         mainStack.spacing = 24
         mainStack.edgeInsets = NSEdgeInsets(top: 30, left: 30, bottom: 30, right: 30)
@@ -180,55 +158,102 @@ class PreferencesViewController: NSViewController {
             hostField.widthAnchor.constraint(equalToConstant: 220),
             highPingField.widthAnchor.constraint(equalToConstant: 220),
             customDNSField.widthAnchor.constraint(equalToConstant: 220),
-            intervalLabel.widthAnchor.constraint(equalToConstant: 180),
-            hostLabel.widthAnchor.constraint(equalToConstant: 180),
-            highPingLabel.widthAnchor.constraint(equalToConstant: 180),
-            customDNSLabel.widthAnchor.constraint(equalToConstant: 180)
+            packetLossProbeIntervalField.widthAnchor.constraint(equalToConstant: 220),
+            packetLossBurstSizeField.widthAnchor.constraint(equalToConstant: 220),
+            packetLossWindowSizeField.widthAnchor.constraint(equalToConstant: 220),
+            packetLossWarningThresholdField.widthAnchor.constraint(equalToConstant: 220),
+            packetLossBadThresholdField.widthAnchor.constraint(equalToConstant: 220),
+            packetLossModePopup.widthAnchor.constraint(equalToConstant: 220)
         ])
 
-        revertDNSCheckbox.state = UserDefaults.standard.bool(forKey: "RevertDNSOnCaptivePortal") ? .on : .off
-        restoreDNSCheckbox.state = UserDefaults.standard.bool(forKey: "RestoreCustomDNSAfterCaptive") ? .on : .off
-        launchAtLoginCheckbox.state = UserDefaults.standard.bool(forKey: "LaunchAtLogin") ? .on : .off
+        revertDNSCheckbox.state = UserDefaults.standard.bool(forKey: UserDefaultsKey.revertDNSOnCaptivePortal) ? .on : .off
+        restoreDNSCheckbox.state = UserDefaults.standard.bool(forKey: UserDefaultsKey.restoreCustomDNSAfterCaptive) ? .on : .off
+        launchAtLoginCheckbox.state = UserDefaults.standard.bool(forKey: UserDefaultsKey.launchAtLogin) ? .on : .off
+        refreshPacketLossFieldState()
     }
 
     @objc func saveClicked() {
-        let interval = Double(intervalField.stringValue) ?? 5.0
-        let host = hostField.stringValue
-        let highPing = Int(highPingField.stringValue) ?? 200
+        let interval = max(1.0, Double(intervalField.stringValue) ?? 5.0)
+        let host = hostField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let highPing = max(1, Int(highPingField.stringValue) ?? 200)
         let customDNS = customDNSField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let mode = packetLossModePopup.titleOfSelectedItem == "Active" ? PingManager.PacketLossMode.active : .passive
+        let packetLossProbeInterval = max(1.0, Double(packetLossProbeIntervalField.stringValue) ?? 30.0)
+        let packetLossBurstSize = clamp(Int(packetLossBurstSizeField.stringValue) ?? 5, min: 1, max: 100)
+        let packetLossWindowSize = clamp(Int(packetLossWindowSizeField.stringValue) ?? 50, min: 10, max: 500)
+        let packetLossWarningThreshold = max(0.1, Double(packetLossWarningThresholdField.stringValue) ?? 3.0)
+        let packetLossBadThreshold = Double(packetLossBadThresholdField.stringValue) ?? 10.0
 
-        // Validate custom DNS if provided
+        guard !host.isEmpty, URL(string: host) != nil else {
+            showAlert(title: "Invalid Target Host", message: "Please enter a valid URL such as https://www.google.com")
+            return
+        }
+
         if !customDNS.isEmpty {
             let components = customDNS.components(separatedBy: " ")
             let ipAddress = components[0]
-
-            // Basic IP address validation
             if !isValidIPAddress(ipAddress) {
-                let alert = NSAlert()
-                alert.messageText = "Invalid DNS Server"
-                alert.informativeText = "Please enter a valid IP address for the custom DNS server. Examples:\n• 1.1.1.1\n• 8.8.8.8 Google\n• 192.168.1.1 Home Router"
-                alert.alertStyle = .warning
-                alert.runModal()
+                showAlert(title: "Invalid DNS Server", message: "Please enter a valid IP address for the custom DNS server. Examples:\n• 1.1.1.1\n• 8.8.8.8 Google\n• 192.168.1.1 Home Router")
                 return
             }
+        }
+
+        guard packetLossBadThreshold > packetLossWarningThreshold else {
+            showAlert(title: "Invalid Packet Loss Thresholds", message: "The bad packet loss threshold must be higher than the warning threshold.")
+            return
         }
 
         let revertDNS = (revertDNSCheckbox.state == .on)
         let restoreDNS = (restoreDNSCheckbox.state == .on)
         let launchAtLogin = (launchAtLoginCheckbox.state == .on)
-        UserDefaults.standard.set(highPing, forKey: "HighPingThreshold")
-        UserDefaults.standard.set(customDNS, forKey: "CustomDNSServer")
-        UserDefaults.standard.set(revertDNS, forKey: "RevertDNSOnCaptivePortal")
-        UserDefaults.standard.set(restoreDNS, forKey: "RestoreCustomDNSAfterCaptive")
-        UserDefaults.standard.set(launchAtLogin, forKey: "LaunchAtLogin")
-        onSave?(host, interval, highPing, customDNS, revertDNS, restoreDNS, launchAtLogin)
-        self.view.window?.close()
+
+        UserDefaults.standard.set(interval, forKey: UserDefaultsKey.pingInterval)
+        UserDefaults.standard.set(host, forKey: UserDefaultsKey.pingHost)
+        UserDefaults.standard.set(highPing, forKey: UserDefaultsKey.highPingThreshold)
+        UserDefaults.standard.set(customDNS, forKey: UserDefaultsKey.customDNSServer)
+        UserDefaults.standard.set(mode.rawValue, forKey: UserDefaultsKey.packetLossMode)
+        UserDefaults.standard.set(packetLossProbeInterval, forKey: UserDefaultsKey.packetLossProbeInterval)
+        UserDefaults.standard.set(packetLossBurstSize, forKey: UserDefaultsKey.packetLossBurstSize)
+        UserDefaults.standard.set(packetLossWindowSize, forKey: UserDefaultsKey.packetLossWindowSize)
+        UserDefaults.standard.set(packetLossWarningThreshold, forKey: UserDefaultsKey.packetLossWarningThreshold)
+        UserDefaults.standard.set(packetLossBadThreshold, forKey: UserDefaultsKey.packetLossBadThreshold)
+        UserDefaults.standard.set(revertDNS, forKey: UserDefaultsKey.revertDNSOnCaptivePortal)
+        UserDefaults.standard.set(restoreDNS, forKey: UserDefaultsKey.restoreCustomDNSAfterCaptive)
+        UserDefaults.standard.set(launchAtLogin, forKey: UserDefaultsKey.launchAtLogin)
+
+        onSave?()
+        view.window?.close()
+    }
+
+    @objc func cancelClicked() {
+        view.window?.close()
+    }
+
+    @objc private func packetLossModeChanged() {
+        refreshPacketLossFieldState()
+    }
+
+    private func refreshPacketLossFieldState() {
+        let isActive = packetLossModePopup.titleOfSelectedItem == "Active"
+        packetLossProbeIntervalField.isEnabled = isActive
+        packetLossBurstSizeField.isEnabled = isActive
+        packetLossProbeIntervalField.alphaValue = isActive ? 1.0 : 0.55
+        packetLossBurstSizeField.alphaValue = isActive ? 1.0 : 0.55
+    }
+
+    private func defaultInt(for key: String, fallback: Int) -> Int {
+        let value = UserDefaults.standard.integer(forKey: key)
+        return value > 0 ? value : fallback
+    }
+
+    private func defaultDouble(for key: String, fallback: Double) -> Double {
+        let value = UserDefaults.standard.double(forKey: key)
+        return value > 0 ? value : fallback
     }
 
     private func isValidIPAddress(_ ip: String) -> Bool {
         let parts = ip.components(separatedBy: ".")
         guard parts.count == 4 else { return false }
-
         for part in parts {
             guard let number = Int(part), number >= 0 && number <= 255 else {
                 return false
@@ -237,11 +262,46 @@ class PreferencesViewController: NSViewController {
         return true
     }
 
-    @objc func cancelClicked() {
-        self.view.window?.close()
+    private func showAlert(title: String, message: String) {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.runModal()
     }
 
-    // MARK: - UI Styling Helper Methods
+    private func sectionLabel(_ string: String) -> NSTextField {
+        let label = NSTextField(labelWithString: string)
+        label.font = NSFont.systemFont(ofSize: 14, weight: .medium)
+        label.textColor = NSColor.secondaryLabelColor
+        return label
+    }
+
+    private func fieldLabel(_ string: String) -> NSTextField {
+        let label = NSTextField(labelWithString: string)
+        label.alignment = .right
+        label.font = NSFont.systemFont(ofSize: 13, weight: .medium)
+        label.textColor = NSColor.labelColor
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.widthAnchor.constraint(equalToConstant: 180).isActive = true
+        return label
+    }
+
+    private func makeRow(label: NSTextField, control: NSView) -> NSStackView {
+        let row = NSStackView(views: [label, control])
+        row.orientation = .horizontal
+        row.spacing = 12
+        row.alignment = .centerY
+        return row
+    }
+
+    private func verticalStack(spacing: CGFloat) -> NSStackView {
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.spacing = spacing
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }
 
     private func styleTextField(_ textField: NSTextField) {
         textField.font = NSFont.systemFont(ofSize: 13)
@@ -258,6 +318,12 @@ class PreferencesViewController: NSViewController {
         textField.layer?.borderColor = NSColor.separatorColor.cgColor
     }
 
+    private func stylePopup(_ popup: NSPopUpButton) {
+        popup.translatesAutoresizingMaskIntoConstraints = false
+        popup.font = NSFont.systemFont(ofSize: 13)
+        popup.controlSize = .regular
+    }
+
     private func styleCheckbox(_ checkbox: NSButton) {
         checkbox.font = NSFont.systemFont(ofSize: 13)
         checkbox.controlSize = .regular
@@ -267,14 +333,11 @@ class PreferencesViewController: NSViewController {
         button.bezelStyle = .rounded
         button.font = NSFont.systemFont(ofSize: 13, weight: isPrimary ? .semibold : .regular)
         button.controlSize = .regular
-
         if isPrimary {
             button.keyEquivalent = "\r"
         }
-
         button.wantsLayer = true
         button.layer?.cornerRadius = 6
-
         if isPrimary {
             button.layer?.backgroundColor = NSColor.controlAccentColor.cgColor
             button.contentTintColor = NSColor.white
@@ -292,14 +355,18 @@ class PreferencesViewController: NSViewController {
 }
 
 class PreferencesWindowController: NSWindowController {
-    convenience init(onSave: @escaping (String, Double, Int, String, Bool, Bool, Bool) -> Void) {
+    convenience init(onSave: @escaping () -> Void) {
         let vc = PreferencesViewController()
         vc.onSave = onSave
         let window = NSWindow(contentViewController: vc)
         window.title = "Preferences"
         window.styleMask = [.titled, .closable]
-        window.setContentSize(NSSize(width: 480, height: 340))
+        window.setContentSize(NSSize(width: 520, height: 520))
         window.center()
         self.init(window: window)
     }
+}
+
+private func clamp<T: Comparable>(_ value: T, min minValue: T, max maxValue: T) -> T {
+    Swift.max(minValue, Swift.min(value, maxValue))
 }

--- a/Sources/StatusIconRenderer.swift
+++ b/Sources/StatusIconRenderer.swift
@@ -1,0 +1,110 @@
+import Cocoa
+
+/// Renders a combined menu bar icon as a programmatic NSImage.
+/// Inner filled circle represents latency status; outer ring represents packet loss level.
+struct StatusIconRenderer {
+
+    /// Render the combined status icon.
+    /// - Parameters:
+    ///   - latencyMs: Current latency in milliseconds, or nil if network is down.
+    ///   - lossLevel: Current packet loss classification.
+    ///   - pingStatus: Current ping status (good/warning/bad/captivePortal).
+    ///   - hasEnoughLossSamples: Whether enough samples exist for a meaningful loss reading.
+    /// - Returns: An NSImage suitable for the menu bar status item.
+    static func render(
+        latencyMs: Int?,
+        lossLevel: LossTracker.LossLevel,
+        pingStatus: PingManager.PingStatus,
+        hasEnoughLossSamples: Bool
+    ) -> NSImage {
+        let size = NSSize(width: 18, height: 18)
+        let image = NSImage(size: size, flipped: false) { rect in
+            let center = NSPoint(x: rect.midX, y: rect.midY)
+            let outerRadius: CGFloat = 7.0
+            let ringWidth: CGFloat = 2.0
+            let gap: CGFloat = 0.5
+            let innerRadius = outerRadius - ringWidth - gap
+
+            // Draw outer ring (packet loss)
+            let ringColor = self.ringColor(for: lossLevel, hasEnoughSamples: hasEnoughLossSamples)
+            let ringPath = NSBezierPath()
+            ringPath.appendArc(withCenter: center, radius: outerRadius - ringWidth / 2, startAngle: 0, endAngle: 360)
+            ringColor.setStroke()
+            ringPath.lineWidth = ringWidth
+            ringPath.stroke()
+
+            // Draw inner filled circle (latency)
+            let fillColor = self.fillColor(for: pingStatus, latencyMs: latencyMs)
+            let innerPath = NSBezierPath()
+            innerPath.appendArc(withCenter: center, radius: innerRadius, startAngle: 0, endAngle: 360)
+            fillColor.setFill()
+            innerPath.fill()
+
+            return true
+        }
+        image.isTemplate = false
+        return image
+    }
+
+    // MARK: - Color Mapping
+
+    /// Maps latency to a fill color using 6 discrete bands.
+    private static func fillColor(for status: PingManager.PingStatus, latencyMs: Int?) -> NSColor {
+        switch status {
+        case .captivePortal:
+            return NSColor.systemPurple
+        case .bad:
+            return NSColor(calibratedRed: 0.4, green: 0.4, blue: 0.4, alpha: 1.0) // dark gray
+        case .good, .warning:
+            guard let ms = latencyMs else {
+                return NSColor(calibratedRed: 0.4, green: 0.4, blue: 0.4, alpha: 1.0)
+            }
+            return latencyBandColor(ms: ms)
+        }
+    }
+
+    /// 6-band latency color gradient.
+    private static func latencyBandColor(ms: Int) -> NSColor {
+        switch ms {
+        case ..<50:
+            return NSColor.systemGreen
+        case 50..<100:
+            return interpolate(from: NSColor.systemGreen, to: NSColor.systemYellow, fraction: Double(ms - 50) / 50.0)
+        case 100..<200:
+            return interpolate(from: NSColor.systemYellow, to: NSColor.systemOrange, fraction: Double(ms - 100) / 100.0)
+        case 200..<400:
+            return interpolate(from: NSColor.systemOrange, to: NSColor.systemRed, fraction: Double(ms - 200) / 200.0)
+        default:
+            return NSColor.systemRed
+        }
+    }
+
+    /// Maps packet loss level to ring color. Neutral gray while collecting.
+    private static func ringColor(for level: LossTracker.LossLevel, hasEnoughSamples: Bool) -> NSColor {
+        guard hasEnoughSamples else {
+            return NSColor(calibratedRed: 0.6, green: 0.6, blue: 0.6, alpha: 1.0)
+        }
+        switch level {
+        case .good:
+            return NSColor.systemGreen
+        case .warning:
+            return NSColor.systemYellow
+        case .bad:
+            return NSColor.systemRed
+        }
+    }
+
+    /// Linear interpolation between two NSColors in sRGB space.
+    private static func interpolate(from: NSColor, to: NSColor, fraction: Double) -> NSColor {
+        let f = max(0, min(1, fraction))
+        guard let fromRGB = from.usingColorSpace(.sRGB),
+              let toRGB = to.usingColorSpace(.sRGB) else {
+            return from
+        }
+        let r = fromRGB.redComponent + CGFloat(f) * (toRGB.redComponent - fromRGB.redComponent)
+        let g = fromRGB.greenComponent + CGFloat(f) * (toRGB.greenComponent - fromRGB.greenComponent)
+        let b = fromRGB.blueComponent + CGFloat(f) * (toRGB.blueComponent - fromRGB.blueComponent)
+        let a = fromRGB.alphaComponent + CGFloat(f) * (toRGB.alphaComponent - fromRGB.alphaComponent)
+        return NSColor(srgbRed: r, green: g, blue: b, alpha: a)
+    }
+}

--- a/Sources/UserDefaultsKeys.swift
+++ b/Sources/UserDefaultsKeys.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum UserDefaultsKey {
+    // Existing keys
+    static let pingHost = "PingHost"
+    static let pingInterval = "PingInterval"
+    static let highPingThreshold = "HighPingThreshold"
+    static let customDNSServer = "CustomDNSServer"
+    static let revertDNSOnCaptivePortal = "RevertDNSOnCaptivePortal"
+    static let restoreCustomDNSAfterCaptive = "RestoreCustomDNSAfterCaptive"
+    static let launchAtLogin = "LaunchAtLogin"
+    static let lastCustomDNS = "LastCustomDNS"
+
+    // Packet loss keys
+    static let packetLossMode = "PacketLossMode"
+    static let packetLossWindowSize = "PacketLossWindowSize"
+    static let packetLossWarningThreshold = "PacketLossWarningThreshold"
+    static let packetLossBadThreshold = "PacketLossBadThreshold"
+    static let packetLossProbeInterval = "PacketLossProbeInterval"
+    static let packetLossBurstSize = "PacketLossBurstSize"
+}

--- a/Tests/PingBarTests/LossTrackerTests.swift
+++ b/Tests/PingBarTests/LossTrackerTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import PingBarLib
+
+final class LossTrackerTests: XCTestCase {
+
+    func testInitialState() {
+        let tracker = LossTracker()
+        XCTAssertEqual(tracker.lossPercent, 0.0)
+        XCTAssertEqual(tracker.level, .good)
+        XCTAssertEqual(tracker.sampleCount, 0)
+        XCTAssertFalse(tracker.hasEnoughSamples)
+    }
+
+    func testAllSuccessZeroLoss() {
+        let tracker = LossTracker(config: .init(windowSize: 20, warningThreshold: 3.0, badThreshold: 10.0))
+        for _ in 0..<20 {
+            tracker.record(success: true)
+        }
+        XCTAssertEqual(tracker.lossPercent, 0.0)
+        XCTAssertEqual(tracker.level, .good)
+        XCTAssertEqual(tracker.sampleCount, 20)
+        XCTAssertTrue(tracker.hasEnoughSamples)
+    }
+
+    func testAllFailureFullLoss() {
+        let tracker = LossTracker(config: .init(windowSize: 10, warningThreshold: 3.0, badThreshold: 10.0))
+        for _ in 0..<10 {
+            tracker.record(success: false)
+        }
+        XCTAssertEqual(tracker.lossPercent, 100.0)
+        XCTAssertEqual(tracker.level, .bad)
+    }
+
+    func testMixedResults() {
+        let tracker = LossTracker(config: .init(windowSize: 20, warningThreshold: 3.0, badThreshold: 10.0))
+        // 18 success + 2 failure = 10% loss
+        for _ in 0..<18 {
+            tracker.record(success: true)
+        }
+        for _ in 0..<2 {
+            tracker.record(success: false)
+        }
+        XCTAssertEqual(tracker.lossPercent, 10.0)
+        XCTAssertEqual(tracker.level, .bad)
+    }
+
+    func testWarningThreshold() {
+        // 5% loss with warning at 3% and bad at 10%
+        let tracker = LossTracker(config: .init(windowSize: 20, warningThreshold: 3.0, badThreshold: 10.0))
+        for _ in 0..<19 {
+            tracker.record(success: true)
+        }
+        tracker.record(success: false) // 1/20 = 5%
+        XCTAssertEqual(tracker.lossPercent, 5.0)
+        XCTAssertEqual(tracker.level, .warning)
+    }
+
+    func testNonCountableSamplesIgnored() {
+        let tracker = LossTracker(config: .init(windowSize: 20, warningThreshold: 3.0, badThreshold: 10.0))
+        tracker.record(success: true)
+        tracker.record(success: false, isCountable: false) // captive portal — ignored
+        tracker.record(success: false, isCountable: false) // ignored
+        tracker.record(success: true)
+
+        XCTAssertEqual(tracker.sampleCount, 2)
+        XCTAssertEqual(tracker.lossPercent, 0.0)
+        XCTAssertEqual(tracker.level, .good)
+    }
+
+    func testWindowSlidingEvictsOldResults() {
+        let tracker = LossTracker(config: .init(windowSize: 10, warningThreshold: 3.0, badThreshold: 10.0))
+
+        // Fill window with 10 failures
+        for _ in 0..<10 {
+            tracker.record(success: false)
+        }
+        XCTAssertEqual(tracker.lossPercent, 100.0)
+
+        // Push 10 successes — failures slide out
+        for _ in 0..<10 {
+            tracker.record(success: true)
+        }
+        XCTAssertEqual(tracker.sampleCount, 10)
+        XCTAssertEqual(tracker.lossPercent, 0.0)
+        XCTAssertEqual(tracker.level, .good)
+    }
+
+    func testReset() {
+        let tracker = LossTracker(config: .init(windowSize: 10, warningThreshold: 3.0, badThreshold: 10.0))
+        for _ in 0..<10 {
+            tracker.record(success: false)
+        }
+        XCTAssertEqual(tracker.level, .bad)
+
+        tracker.reset()
+        XCTAssertEqual(tracker.sampleCount, 0)
+        XCTAssertEqual(tracker.lossPercent, 0.0)
+        XCTAssertEqual(tracker.level, .good)
+        XCTAssertFalse(tracker.hasEnoughSamples)
+    }
+
+    func testUpdateConfigurationTrimsWindow() {
+        let tracker = LossTracker(config: .init(windowSize: 50, warningThreshold: 3.0, badThreshold: 10.0))
+        for _ in 0..<30 {
+            tracker.record(success: true)
+        }
+        XCTAssertEqual(tracker.sampleCount, 30)
+
+        // Shrink window — oldest samples evicted
+        tracker.updateConfiguration(.init(windowSize: 10, warningThreshold: 3.0, badThreshold: 10.0))
+        XCTAssertEqual(tracker.sampleCount, 10)
+    }
+
+    func testConfigurationClampingMinWindowSize() {
+        // windowSize below minimum 10 should be clamped
+        let tracker = LossTracker(config: .init(windowSize: 2, warningThreshold: 3.0, badThreshold: 10.0))
+        for _ in 0..<15 {
+            tracker.record(success: true)
+        }
+        // Window clamped to 10, so 15 samples should be trimmed to 10
+        XCTAssertEqual(tracker.sampleCount, 10)
+    }
+
+    func testConfigurationClampingMaxWindowSize() {
+        // windowSize above maximum 500 should be clamped
+        let tracker = LossTracker(config: .init(windowSize: 1000, warningThreshold: 3.0, badThreshold: 10.0))
+        for _ in 0..<600 {
+            tracker.record(success: true)
+        }
+        XCTAssertEqual(tracker.sampleCount, 500)
+    }
+
+    func testConfigurationClampingBadThresholdAboveWarning() {
+        // bad threshold must be at least warning + 0.1
+        let tracker = LossTracker(config: .init(windowSize: 20, warningThreshold: 10.0, badThreshold: 5.0))
+        // 10% loss: bad threshold was clamped to 10.1, so at exactly 10% this is warning not bad
+        for _ in 0..<18 {
+            tracker.record(success: true)
+        }
+        for _ in 0..<2 {
+            tracker.record(success: false)
+        }
+        XCTAssertEqual(tracker.lossPercent, 10.0)
+        XCTAssertEqual(tracker.level, .warning) // 10.0 < 10.1 (clamped bad threshold)
+    }
+
+    func testHasEnoughSamples() {
+        let tracker = LossTracker()
+        XCTAssertFalse(tracker.hasEnoughSamples)
+        tracker.record(success: true)
+        XCTAssertFalse(tracker.hasEnoughSamples)
+        tracker.record(success: true)
+        XCTAssertFalse(tracker.hasEnoughSamples)
+        tracker.record(success: true)
+        XCTAssertTrue(tracker.hasEnoughSamples)
+    }
+
+    func testExactThresholdBoundaries() {
+        // Exactly at warning threshold should be warning
+        let config = LossTracker.Configuration(windowSize: 100, warningThreshold: 5.0, badThreshold: 10.0)
+        let tracker = LossTracker(config: config)
+        for _ in 0..<95 { tracker.record(success: true) }
+        for _ in 0..<5 { tracker.record(success: false) }
+        XCTAssertEqual(tracker.lossPercent, 5.0)
+        XCTAssertEqual(tracker.level, .warning)
+    }
+}

--- a/Tests/PingBarTests/PingManagerTests.swift
+++ b/Tests/PingBarTests/PingManagerTests.swift
@@ -3,52 +3,94 @@ import XCTest
 
 @MainActor
 final class PingManagerTests: XCTestCase {
-    
+
     var pingManager: PingManager!
-    
+
     override func setUp() {
         super.setUp()
-        UserDefaults.standard.removeObject(forKey: "HighPingThreshold")
-        UserDefaults.standard.removeObject(forKey: "PingHost")
-        UserDefaults.standard.removeObject(forKey: "PingInterval")
+        clearDefaults()
         pingManager = PingManager()
     }
 
     override func tearDown() {
         pingManager.stop()
         pingManager = nil
-        UserDefaults.standard.removeObject(forKey: "HighPingThreshold")
-        UserDefaults.standard.removeObject(forKey: "PingHost")
-        UserDefaults.standard.removeObject(forKey: "PingInterval")
+        clearDefaults()
         super.tearDown()
     }
-    
+
     func testInitialization() {
         XCTAssertNotNil(pingManager)
         XCTAssertEqual(pingManager.currentHost, "www.google.com")
         XCTAssertEqual(pingManager.highPingThreshold, 200)
+        XCTAssertEqual(pingManager.packetLossMode, .passive)
+        XCTAssertEqual(pingManager.packetLossWindowSize, 50)
     }
-    
+
     func testUpdateSettings() {
         let newHost = "https://www.example.com"
         let newInterval = 10.0
-        
+
         pingManager.updateSettings(host: newHost, interval: newInterval)
-        
+
         XCTAssertEqual(pingManager.currentHost, "www.example.com")
     }
-    
+
     func testHighPingThresholdUpdate() {
         let newThreshold = 150
         pingManager.highPingThreshold = newThreshold
         XCTAssertEqual(pingManager.highPingThreshold, newThreshold)
     }
-    
+
+    func testReloadSettingsUsesPacketLossDefaults() {
+        UserDefaults.standard.set(PingManager.PacketLossMode.active.rawValue, forKey: UserDefaultsKey.packetLossMode)
+        UserDefaults.standard.set(80, forKey: UserDefaultsKey.packetLossWindowSize)
+        UserDefaults.standard.set(4.0, forKey: UserDefaultsKey.packetLossWarningThreshold)
+        UserDefaults.standard.set(12.0, forKey: UserDefaultsKey.packetLossBadThreshold)
+        UserDefaults.standard.set(2.0, forKey: UserDefaultsKey.packetLossProbeInterval)
+        UserDefaults.standard.set(9, forKey: UserDefaultsKey.packetLossBurstSize)
+
+        pingManager.reloadSettingsFromDefaults(restartIfRunning: false)
+
+        XCTAssertEqual(pingManager.packetLossMode, .active)
+        XCTAssertEqual(pingManager.packetLossWindowSize, 80)
+    }
+
+    func testReloadSettingsResetsLossTrackerWhenModeChanges() {
+        pingManager.lossTracker.record(success: false)
+        pingManager.lossTracker.record(success: false)
+        pingManager.lossTracker.record(success: false)
+        XCTAssertEqual(pingManager.lossTracker.sampleCount, 3)
+
+        UserDefaults.standard.set(PingManager.PacketLossMode.active.rawValue, forKey: UserDefaultsKey.packetLossMode)
+        pingManager.reloadSettingsFromDefaults(restartIfRunning: false)
+
+        XCTAssertEqual(pingManager.lossTracker.sampleCount, 0)
+        XCTAssertEqual(pingManager.packetLossMode, .active)
+    }
+
     func testRecentPingsTracking() {
         // Initially empty
         XCTAssertTrue(pingManager.getRecentPings().isEmpty)
-        
+
         // Simulate adding pings (would normally come from network requests)
         // This test would need to be expanded with proper mocking for actual network tests
+    }
+
+    private func clearDefaults() {
+        let keys = [
+            UserDefaultsKey.highPingThreshold,
+            UserDefaultsKey.pingHost,
+            UserDefaultsKey.pingInterval,
+            UserDefaultsKey.packetLossMode,
+            UserDefaultsKey.packetLossWindowSize,
+            UserDefaultsKey.packetLossWarningThreshold,
+            UserDefaultsKey.packetLossBadThreshold,
+            UserDefaultsKey.packetLossProbeInterval,
+            UserDefaultsKey.packetLossBurstSize
+        ]
+        for key in keys {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
     }
 }

--- a/Tests/PingBarTests/StatusIconRendererTests.swift
+++ b/Tests/PingBarTests/StatusIconRendererTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import PingBarLib
+
+@MainActor
+final class StatusIconRendererTests: XCTestCase {
+
+    func testRenderReturnsNonNilImageForAllCombinations() {
+        let statuses: [PingManager.PingStatus] = [.good, .warning, .bad, .captivePortal]
+        let levels: [LossTracker.LossLevel] = [.good, .warning, .bad]
+
+        for status in statuses {
+            for level in levels {
+                let latencyMs: Int? = (status == .bad || status == .captivePortal) ? nil : 42
+                let image = StatusIconRenderer.render(
+                    latencyMs: latencyMs,
+                    lossLevel: level,
+                    pingStatus: status,
+                    hasEnoughLossSamples: true
+                )
+                XCTAssertNotNil(image, "Icon should not be nil for status=\(status), level=\(level)")
+                XCTAssertEqual(image.size.width, 18, "Icon width should be 18pt")
+                XCTAssertEqual(image.size.height, 18, "Icon height should be 18pt")
+            }
+        }
+    }
+
+    func testRenderWithCollectingState() {
+        // When not enough samples, ring should be neutral (gray) — should still return valid image
+        let image = StatusIconRenderer.render(
+            latencyMs: 50,
+            lossLevel: .good,
+            pingStatus: .good,
+            hasEnoughLossSamples: false
+        )
+        XCTAssertNotNil(image)
+        XCTAssertEqual(image.size.width, 18)
+    }
+
+    func testRenderWithNilLatency() {
+        let image = StatusIconRenderer.render(
+            latencyMs: nil,
+            lossLevel: .bad,
+            pingStatus: .bad,
+            hasEnoughLossSamples: true
+        )
+        XCTAssertNotNil(image)
+    }
+
+    func testRenderWithHighLatency() {
+        let image = StatusIconRenderer.render(
+            latencyMs: 1000,
+            lossLevel: .good,
+            pingStatus: .warning,
+            hasEnoughLossSamples: true
+        )
+        XCTAssertNotNil(image)
+    }
+}


### PR DESCRIPTION
## Motivation
The tray icon currently only shows a coarse four-state latency signal, which makes it hard to distinguish between slow but stable connectivity and real packet loss. This change adds a lightweight packet loss metric and surfaces both dimensions together without introducing a second tray item.

## Summary
- add packet loss monitoring with passive and active modes, rolling loss tracking, and configurable thresholds
- replace the single 4-state dot with a dual-state tray icon that shows latency in the center and packet loss on the outer ring
- extend preferences and menu status display to expose packet loss settings, current mode, and current loss percentage

## Verification
- `swift build`
- `swift test` is currently blocked in this environment because only Command Line Tools are installed and the XCTest module is unavailable locally