### PR TITLE
Improve menu readability

### DIFF
--- a/Sources/PingBarApp.swift
+++ b/Sources/PingBarApp.swift
@@ -15,6 +15,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
     private var dnsRevertedForOutage = false
     private var customDNSBeforeCaptive: String?
     private var graphMenuItem: NSMenuItem?
+    private var statsMenuItem: NSMenuItem?
     private var latestLatencyMs: Int?
     private var latestPingStatus: PingManager.PingStatus = .bad
 
@@ -30,6 +31,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
 
         let menu = NSMenu()
         menu.delegate = self
+        menu.autoenablesItems = false
 
         let pingItem = NSMenuItem(title: "Checking...", action: nil, keyEquivalent: "")
         self.stylePingMenuItem(pingItem)
@@ -39,27 +41,31 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
         self.styleGraphMenuItem(graphItem)
         menu.addItem(graphItem)
 
+        let statsItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        self.styleStatsMenuItem(statsItem)
+        menu.addItem(statsItem)
+
         let lossItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
-        self.styleGraphMenuItem(lossItem)
+        self.styleLossMenuItem(lossItem)
         menu.addItem(lossItem)
 
         menu.addItem(.separator())
 
-        let prefsItem = NSMenuItem(title: "⚙ Preferences…", action: #selector(showPreferences), keyEquivalent: ",")
+        let prefsItem = NSMenuItem(title: "Preferences…", action: #selector(showPreferences), keyEquivalent: ",")
         self.styleSystemMenuItem(prefsItem)
         menu.addItem(prefsItem)
 
-        menu.addItem(.separator())
-
-        let quitItem = NSMenuItem(title: "⏻ Quit PingBar", action: #selector(quit), keyEquivalent: "q")
-        self.styleSystemMenuItem(quitItem)
+        let quitItem = NSMenuItem(title: "Quit PingBar", action: #selector(quit), keyEquivalent: "q")
+        self.styleQuitMenuItem(quitItem)
         menu.addItem(quitItem)
         statusItem?.menu = menu
         self.pingMenuItem = pingItem
         self.graphMenuItem = graphItem
+        self.statsMenuItem = statsItem
         self.packetLossMenuItem = lossItem
         self.preferencesMenuItem = prefsItem
         self.graphMenuItem?.isHidden = true
+        self.statsMenuItem?.isHidden = true
         self.packetLossMenuItem?.isHidden = true
 
         pingManager.onPingResult = { [weak self] result in
@@ -70,18 +76,22 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
             self.latestLatencyMs = result.latencyMs
             let pings = self.pingManager.recentPings
             if !pings.isEmpty {
-                let spark = SparklineRenderer.renderSparkline(pings: pings)
-                let avg = pings.reduce(0, +) / pings.count
-                let minPing = pings.min() ?? 0
-                let maxPing = pings.max() ?? 0
-                self.graphMenuItem?.title = "📊 \(spark)  ⌀ \(avg)ms  ↓ \(minPing)ms  ↑ \(maxPing)ms"
+                self.graphMenuItem?.title = self.graphTitle(for: pings)
                 if let graphItem = self.graphMenuItem {
                     self.styleGraphMenuItem(graphItem)
                 }
                 self.graphMenuItem?.isHidden = false
+
+                self.statsMenuItem?.title = self.statsTitle(for: pings)
+                if let statsItem = self.statsMenuItem {
+                    self.styleStatsMenuItem(statsItem)
+                }
+                self.statsMenuItem?.isHidden = false
             } else {
                 self.graphMenuItem?.title = ""
                 self.graphMenuItem?.isHidden = true
+                self.statsMenuItem?.title = ""
+                self.statsMenuItem?.isHidden = true
             }
             switch result.status {
             case .good, .warning:
@@ -131,10 +141,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
         guard let preferencesMenuItem, let baseInsertIndex = menu.items.firstIndex(of: preferencesMenuItem) else { return }
         var insertIndex = baseInsertIndex
         let ifaces = NetworkUtilities.localInterfaceAddresses()
-        if !ifaces.isEmpty {
+        let showNetworkInterfaces = shouldShowNetworkInterfaces()
+        if showNetworkInterfaces, !ifaces.isEmpty {
             for (idx, (iface, ip)) in ifaces.enumerated() {
                 let ipItem = NSMenuItem(title: "🌐 \(iface): \(ip)", action: nil, keyEquivalent: "")
-                self.styleInfoMenuItem(ipItem)
+                self.styleNetworkInterfaceMenuItem(ipItem)
                 menu.insertItem(ipItem, at: insertIndex + idx)
                 ipMenuItems.append(ipItem)
             }
@@ -144,24 +155,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
             insertIndex += ifaces.count + 1
         }
         let dnsResolvers = NetworkUtilities.currentDNSResolvers()
-        if !dnsResolvers.isEmpty {
-            let sep = NSMenuItem.separator()
-            menu.insertItem(sep, at: insertIndex)
-            ipMenuItems.append(sep)
-            insertIndex += 1
-            for (idx, dns) in dnsResolvers.enumerated() {
-                let display = DNSManager.displayName(for: dns)
-                let dnsItem = NSMenuItem(title: "🔍 DNS: \(display)", action: nil, keyEquivalent: "")
-                self.styleInfoMenuItem(dnsItem)
-                menu.insertItem(dnsItem, at: insertIndex + idx)
-                ipMenuItems.append(dnsItem)
-            }
-            let sepAfter = NSMenuItem.separator()
-            menu.insertItem(sepAfter, at: insertIndex + dnsResolvers.count)
-            ipMenuItems.append(sepAfter)
-            insertIndex += dnsResolvers.count + 1
-        }
-        let dnsMenu = NSMenu(title: "Set DNS for Default Interface")
+        let dnsMenu = NSMenu(title: "DNS")
+        let currentDNSItem = NSMenuItem(
+            title: currentDNSSummary(from: dnsResolvers),
+            action: nil,
+            keyEquivalent: ""
+        )
+        self.styleInfoMenuItem(currentDNSItem)
+        dnsMenu.addItem(currentDNSItem)
+        dnsMenu.addItem(.separator())
+
         var dnsOptions: [(String, String?)] = [
             ("🏠 System Default", nil),
             ("🔒 dnscrypt-proxy (127.0.0.1)", "127.0.0.1"),
@@ -190,9 +193,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
             self.styleDNSMenuItem(item)
             dnsMenu.addItem(item)
         }
-        let dnsMenuItem = NSMenuItem(title: "🔧 Set DNS for Default Interface", action: nil, keyEquivalent: "")
+        let dnsMenuItem = NSMenuItem(title: "DNS", action: nil, keyEquivalent: "")
         dnsMenuItem.submenu = dnsMenu
-        self.styleSystemMenuItem(dnsMenuItem)
+        self.styleDNSRootMenuItem(dnsMenuItem)
         menu.insertItem(dnsMenuItem, at: insertIndex)
         self.dnsMenuItem = dnsMenuItem
     }
@@ -283,53 +286,139 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
         guard let item = packetLossMenuItem else { return }
         let sampleCount = pingManager.lossTracker.sampleCount
         let windowSize = pingManager.packetLossWindowSize
-        let mode = pingManager.packetLossMode.displayName.lowercased()
-        if pingManager.lossTracker.hasEnoughSamples {
-            let lossText = String(format: "%.1f", pingManager.lossTracker.lossPercent)
-            item.title = "📉 Loss: \(lossText)% (\(mode), \(sampleCount)/\(windowSize))"
-            item.isHidden = false
-        } else if sampleCount > 0 {
-            item.title = "📉 Loss: collecting (\(mode), \(sampleCount)/\(windowSize))"
-            item.isHidden = false
-        } else {
+        item.title = packetLossTitle(
+            lossPercent: pingManager.lossTracker.lossPercent,
+            mode: pingManager.packetLossMode.displayName,
+            sampleCount: sampleCount,
+            windowSize: windowSize,
+            hasEnoughSamples: pingManager.lossTracker.hasEnoughSamples
+        )
+        if item.title.isEmpty {
             item.title = ""
             item.isHidden = true
+        } else {
+            item.isHidden = false
         }
-        styleGraphMenuItem(item)
+        styleLossMenuItem(item)
+    }
+
+    func shouldShowNetworkInterfaces() -> Bool {
+        if UserDefaults.standard.object(forKey: UserDefaultsKey.showNetworkInterfaces) == nil {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: UserDefaultsKey.showNetworkInterfaces)
+    }
+
+    func currentDNSSummary(from resolvers: [String]) -> String {
+        guard !resolvers.isEmpty else {
+            return "Current: Unavailable"
+        }
+
+        let names = resolvers.map(DNSManager.displayName(for:))
+        return "Current: \(names.joined(separator: ", "))"
+    }
+
+    func graphTitle(for pings: [Int]) -> String {
+        guard !pings.isEmpty else {
+            return ""
+        }
+
+        let spark = SparklineRenderer.renderSparkline(pings: pings)
+        return "Trend  \(spark)"
+    }
+
+    func statsTitle(for pings: [Int]) -> String {
+        guard !pings.isEmpty else {
+            return ""
+        }
+
+        let avg = pings.reduce(0, +) / pings.count
+        let sorted = pings.sorted()
+        let minPing = sorted.first ?? 0
+        let maxPing = sorted.last ?? 0
+        let median: Int
+
+        if sorted.count.isMultiple(of: 2) {
+            let upperMiddle = sorted.count / 2
+            let lowerMiddle = upperMiddle - 1
+            median = (sorted[lowerMiddle] + sorted[upperMiddle]) / 2
+        } else {
+            median = sorted[sorted.count / 2]
+        }
+
+        return "avg \(avg)ms | med \(median)ms | min \(minPing)ms | max \(maxPing)ms"
+    }
+
+    func packetLossTitle(
+        lossPercent: Double,
+        mode: String,
+        sampleCount: Int,
+        windowSize: Int,
+        hasEnoughSamples: Bool
+    ) -> String {
+        guard hasEnoughSamples || sampleCount > 0 else {
+            return ""
+        }
+
+        let modeLabel = mode.lowercased()
+        if hasEnoughSamples {
+            return String(format: "Loss  %.1f%% | %@ | %d/%d", lossPercent, modeLabel, sampleCount, windowSize)
+        }
+
+        return "Loss  collecting | \(modeLabel) | \(sampleCount)/\(windowSize)"
     }
 
     private func stylePingMenuItem(_ item: NSMenuItem) {
-        let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .medium)
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: NSColor.labelColor
-        ]
-        let attributedTitle = NSAttributedString(string: item.title, attributes: attributes)
-        item.attributedTitle = attributedTitle
+        let font = NSFont.monospacedSystemFont(ofSize: 17, weight: .semibold)
+        styleStaticMenuItem(
+            item,
+            font: font,
+            color: pingHeadlineColor(for: item.title),
+            minimumWidth: 350,
+            verticalPadding: 5
+        )
     }
 
     private func styleGraphMenuItem(_ item: NSMenuItem) {
-        let font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: NSColor.secondaryLabelColor
-        ]
-        let attributedTitle = NSAttributedString(string: item.title, attributes: attributes)
-        item.attributedTitle = attributedTitle
+        let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        styleStaticMenuItem(item, font: font, color: .labelColor, minimumWidth: 350, verticalPadding: 3)
+    }
+
+    private func styleStatsMenuItem(_ item: NSMenuItem) {
+        let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+        styleStaticMenuItem(item, font: font, color: .secondaryLabelColor, minimumWidth: 350, verticalPadding: 2)
+    }
+
+    private func styleLossMenuItem(_ item: NSMenuItem) {
+        let font = NSFont.systemFont(ofSize: 13, weight: .medium)
+        styleStaticMenuItem(
+            item,
+            font: font,
+            color: packetLossRowColor(),
+            minimumWidth: 350,
+            verticalPadding: 3
+        )
     }
 
     private func styleInfoMenuItem(_ item: NSMenuItem) {
         let font = NSFont.systemFont(ofSize: 12, weight: .regular)
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: NSColor.tertiaryLabelColor
-        ]
-        let attributedTitle = NSAttributedString(string: item.title, attributes: attributes)
-        item.attributedTitle = attributedTitle
+        styleStaticMenuItem(item, font: font, color: .labelColor)
+    }
+
+    private func styleNetworkInterfaceMenuItem(_ item: NSMenuItem) {
+        let font = NSFont.systemFont(ofSize: 12, weight: .regular)
+        styleStaticMenuItem(
+            item,
+            font: font,
+            color: .secondaryLabelColor,
+            verticalPadding: 5
+        )
     }
 
     private func styleSystemMenuItem(_ item: NSMenuItem) {
-        let font = NSFont.systemFont(ofSize: 13, weight: .medium)
+        item.isEnabled = true
+        item.view = nil
+        let font = NSFont.systemFont(ofSize: 12, weight: .medium)
         let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: NSColor.labelColor
@@ -339,6 +428,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
     }
 
     private func styleDNSMenuItem(_ item: NSMenuItem) {
+        item.isEnabled = true
+        item.view = nil
         let font = NSFont.systemFont(ofSize: 12, weight: .regular)
         let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
@@ -346,6 +437,101 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate 
         ]
         let attributedTitle = NSAttributedString(string: item.title, attributes: attributes)
         item.attributedTitle = attributedTitle
+    }
+
+    private func styleDNSRootMenuItem(_ item: NSMenuItem) {
+        styleSystemMenuItem(item)
+        if let image = NSImage(systemSymbolName: "globe", accessibilityDescription: "DNS") {
+            image.isTemplate = true
+            item.image = image
+        }
+    }
+
+    private func styleQuitMenuItem(_ item: NSMenuItem) {
+        styleSystemMenuItem(item)
+        if let image = NSImage(systemSymbolName: "power", accessibilityDescription: "Quit PingBar") {
+            image.isTemplate = true
+            item.image = image
+        }
+    }
+
+    private func pingHeadlineColor(for title: String) -> NSColor {
+        if title == "Checking..." {
+            return .labelColor
+        }
+
+        switch latestPingStatus {
+        case .good:
+            return .labelColor
+        case .warning:
+            return .systemOrange
+        case .bad:
+            return .systemRed
+        case .captivePortal:
+            return .systemYellow
+        }
+    }
+
+    private func packetLossRowColor() -> NSColor {
+        if !pingManager.lossTracker.hasEnoughSamples {
+            return .secondaryLabelColor
+        }
+
+        switch pingManager.lossTracker.level {
+        case .good:
+            return .labelColor
+        case .warning:
+            return .systemOrange
+        case .bad:
+            return .systemRed
+        }
+    }
+
+    private func styleStaticMenuItem(
+        _ item: NSMenuItem,
+        font: NSFont,
+        color: NSColor,
+        minimumWidth: CGFloat = 220,
+        verticalPadding: CGFloat = 2
+    ) {
+        item.isEnabled = false
+        item.attributedTitle = nil
+        item.view = makeMenuLabelView(
+            text: item.title,
+            font: font,
+            color: color,
+            minimumWidth: minimumWidth,
+            verticalPadding: verticalPadding
+        )
+    }
+
+    private func makeMenuLabelView(
+        text: String,
+        font: NSFont,
+        color: NSColor,
+        minimumWidth: CGFloat,
+        verticalPadding: CGFloat
+    ) -> NSView {
+        let label = NSTextField(labelWithString: text)
+        label.font = font
+        label.textColor = color
+        label.lineBreakMode = .byTruncatingTail
+        label.maximumNumberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(label)
+
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 12),
+            label.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -12),
+            label.topAnchor.constraint(equalTo: container.topAnchor, constant: verticalPadding),
+            label.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -verticalPadding),
+            container.widthAnchor.constraint(equalToConstant: max(label.intrinsicContentSize.width + 24, minimumWidth))
+        ])
+
+        return container
     }
 
 }

--- a/Sources/PreferencesWindowController.swift
+++ b/Sources/PreferencesWindowController.swift
@@ -13,6 +13,7 @@ class PreferencesViewController: NSViewController {
     let packetLossBadThresholdField = NSTextField()
     let revertDNSCheckbox = NSButton(checkboxWithTitle: "Revert DNS to System Default when network is unreachable", target: nil, action: nil)
     let restoreDNSCheckbox = NSButton(checkboxWithTitle: "Restore my custom DNS after passing captive portal", target: nil, action: nil)
+    let showNetworkInterfacesCheckbox = NSButton(checkboxWithTitle: "Show network interfaces section in the menu", target: nil, action: nil)
     let launchAtLoginCheckbox = NSButton(checkboxWithTitle: "Launch PingBar at login", target: nil, action: nil)
     var onSave: (() -> Void)?
 
@@ -28,7 +29,8 @@ class PreferencesViewController: NSViewController {
         headerLabel.alignment = .center
         headerLabel.textColor = NSColor.labelColor
 
-        let networkSectionLabel = sectionLabel("🌐 Network Settings")
+        let networkSectionLabel = sectionLabel("📡 Ping Settings")
+        let interfacesSectionLabel = sectionLabel("🌐 Network Interfaces")
         let packetLossSectionLabel = sectionLabel("📉 Packet Loss")
         let dnsSectionLabel = sectionLabel("🔧 DNS Management")
         let systemSectionLabel = sectionLabel("💻 System Integration")
@@ -89,6 +91,7 @@ class PreferencesViewController: NSViewController {
 
         styleCheckbox(revertDNSCheckbox)
         styleCheckbox(restoreDNSCheckbox)
+        styleCheckbox(showNetworkInterfacesCheckbox)
         styleCheckbox(launchAtLoginCheckbox)
 
         let saveButton = NSButton(title: "💾 Save Settings", target: self, action: #selector(saveClicked))
@@ -116,6 +119,10 @@ class PreferencesViewController: NSViewController {
         packetLossStack.addArrangedSubview(makeRow(label: packetLossWarningThresholdLabel, control: packetLossWarningThresholdField))
         packetLossStack.addArrangedSubview(makeRow(label: packetLossBadThresholdLabel, control: packetLossBadThresholdField))
 
+        let interfacesStack = verticalStack(spacing: 8)
+        interfacesStack.addArrangedSubview(interfacesSectionLabel)
+        interfacesStack.addArrangedSubview(showNetworkInterfacesCheckbox)
+
         let dnsStack = verticalStack(spacing: 8)
         dnsStack.addArrangedSubview(dnsSectionLabel)
         dnsStack.addArrangedSubview(revertDNSCheckbox)
@@ -129,6 +136,8 @@ class PreferencesViewController: NSViewController {
         formStack.addArrangedSubview(networkStack)
         formStack.addArrangedSubview(createSeparator())
         formStack.addArrangedSubview(packetLossStack)
+        formStack.addArrangedSubview(createSeparator())
+        formStack.addArrangedSubview(interfacesStack)
         formStack.addArrangedSubview(createSeparator())
         formStack.addArrangedSubview(dnsStack)
         formStack.addArrangedSubview(createSeparator())
@@ -167,6 +176,7 @@ class PreferencesViewController: NSViewController {
 
         revertDNSCheckbox.state = UserDefaults.standard.bool(forKey: UserDefaultsKey.revertDNSOnCaptivePortal) ? .on : .off
         restoreDNSCheckbox.state = UserDefaults.standard.bool(forKey: UserDefaultsKey.restoreCustomDNSAfterCaptive) ? .on : .off
+        showNetworkInterfacesCheckbox.state = showNetworkInterfacesPreference() ? .on : .off
         launchAtLoginCheckbox.state = UserDefaults.standard.bool(forKey: UserDefaultsKey.launchAtLogin) ? .on : .off
         refreshPacketLossFieldState()
     }
@@ -204,6 +214,7 @@ class PreferencesViewController: NSViewController {
 
         let revertDNS = (revertDNSCheckbox.state == .on)
         let restoreDNS = (restoreDNSCheckbox.state == .on)
+        let showNetworkInterfaces = (showNetworkInterfacesCheckbox.state == .on)
         let launchAtLogin = (launchAtLoginCheckbox.state == .on)
 
         UserDefaults.standard.set(interval, forKey: UserDefaultsKey.pingInterval)
@@ -218,6 +229,7 @@ class PreferencesViewController: NSViewController {
         UserDefaults.standard.set(packetLossBadThreshold, forKey: UserDefaultsKey.packetLossBadThreshold)
         UserDefaults.standard.set(revertDNS, forKey: UserDefaultsKey.revertDNSOnCaptivePortal)
         UserDefaults.standard.set(restoreDNS, forKey: UserDefaultsKey.restoreCustomDNSAfterCaptive)
+        UserDefaults.standard.set(showNetworkInterfaces, forKey: UserDefaultsKey.showNetworkInterfaces)
         UserDefaults.standard.set(launchAtLogin, forKey: UserDefaultsKey.launchAtLogin)
 
         onSave?()
@@ -248,6 +260,13 @@ class PreferencesViewController: NSViewController {
     private func defaultDouble(for key: String, fallback: Double) -> Double {
         let value = UserDefaults.standard.double(forKey: key)
         return value > 0 ? value : fallback
+    }
+
+    private func showNetworkInterfacesPreference() -> Bool {
+        if UserDefaults.standard.object(forKey: UserDefaultsKey.showNetworkInterfaces) == nil {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: UserDefaultsKey.showNetworkInterfaces)
     }
 
     private func isValidIPAddress(_ ip: String) -> Bool {

--- a/Sources/UserDefaultsKeys.swift
+++ b/Sources/UserDefaultsKeys.swift
@@ -9,6 +9,7 @@ enum UserDefaultsKey {
     static let revertDNSOnCaptivePortal = "RevertDNSOnCaptivePortal"
     static let restoreCustomDNSAfterCaptive = "RestoreCustomDNSAfterCaptive"
     static let launchAtLogin = "LaunchAtLogin"
+    static let showNetworkInterfaces = "ShowNetworkInterfaces"
     static let lastCustomDNS = "LastCustomDNS"
 
     // Packet loss keys

--- a/Tests/PingBarTests/AppDelegateTests.swift
+++ b/Tests/PingBarTests/AppDelegateTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import PingBarLib
+
+@MainActor
+final class AppDelegateTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKey.showNetworkInterfaces)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKey.customDNSServer)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKey.showNetworkInterfaces)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKey.customDNSServer)
+        super.tearDown()
+    }
+
+    func testShowNetworkInterfacesDefaultsToTrueWhenUnset() {
+        let appDelegate = AppDelegate()
+
+        XCTAssertTrue(appDelegate.shouldShowNetworkInterfaces())
+    }
+
+    func testShowNetworkInterfacesUsesStoredValue() {
+        UserDefaults.standard.set(false, forKey: UserDefaultsKey.showNetworkInterfaces)
+        let appDelegate = AppDelegate()
+
+        XCTAssertFalse(appDelegate.shouldShowNetworkInterfaces())
+    }
+
+    func testCurrentDNSSummaryUsesDisplayNames() {
+        let appDelegate = AppDelegate()
+
+        XCTAssertEqual(
+            appDelegate.currentDNSSummary(from: ["1.1.1.1", "8.8.8.8"]),
+            "Current: Cloudflare, Google"
+        )
+    }
+
+    func testCurrentDNSSummaryHandlesMissingResolvers() {
+        let appDelegate = AppDelegate()
+
+        XCTAssertEqual(appDelegate.currentDNSSummary(from: []), "Current: Unavailable")
+    }
+
+    func testGraphTitleUsesDedicatedTrendLine() {
+        let appDelegate = AppDelegate()
+        let pings = [10, 50, 100, 75]
+
+        XCTAssertEqual(
+            appDelegate.graphTitle(for: pings),
+            "Trend  \(SparklineRenderer.renderSparkline(pings: pings))"
+        )
+    }
+
+    func testStatsTitleFormatsAvgMedianMinMaxForOddCount() {
+        let appDelegate = AppDelegate()
+
+        XCTAssertEqual(
+            appDelegate.statsTitle(for: [10, 50, 100, 75, 20]),
+            "avg 51ms | med 50ms | min 10ms | max 100ms"
+        )
+    }
+
+    func testStatsTitleFormatsMedianForEvenCount() {
+        let appDelegate = AppDelegate()
+
+        XCTAssertEqual(
+            appDelegate.statsTitle(for: [10, 20, 40, 100]),
+            "avg 42ms | med 30ms | min 10ms | max 100ms"
+        )
+    }
+
+    func testPacketLossTitleUsesSimplifiedReadableFormat() {
+        let appDelegate = AppDelegate()
+
+        XCTAssertEqual(
+            appDelegate.packetLossTitle(
+                lossPercent: 31.6,
+                mode: "Passive",
+                sampleCount: 19,
+                windowSize: 50,
+                hasEnoughSamples: true
+            ),
+            "Loss  31.6% | passive | 19/50"
+        )
+    }
+
+    func testPacketLossTitleUsesCollectingStateFormat() {
+        let appDelegate = AppDelegate()
+
+        XCTAssertEqual(
+            appDelegate.packetLossTitle(
+                lossPercent: 0,
+                mode: "Passive",
+                sampleCount: 1,
+                windowSize: 50,
+                hasEnoughSamples: false
+            ),
+            "Loss  collecting | passive | 1/50"
+        )
+    }
+}

--- a/Tests/PingBarTests/PreferencesViewControllerTests.swift
+++ b/Tests/PingBarTests/PreferencesViewControllerTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import PingBarLib
+
+@MainActor
+final class PreferencesViewControllerTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKey.showNetworkInterfaces)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKey.showNetworkInterfaces)
+        super.tearDown()
+    }
+
+    func testShowNetworkInterfacesCheckboxDefaultsToOnWhenUnset() {
+        let viewController = PreferencesViewController()
+
+        viewController.loadViewIfNeeded()
+
+        XCTAssertEqual(viewController.showNetworkInterfacesCheckbox.state, .on)
+    }
+
+    func testSavePersistsShowNetworkInterfacesPreference() {
+        let viewController = PreferencesViewController()
+        viewController.loadViewIfNeeded()
+        viewController.showNetworkInterfacesCheckbox.state = .off
+
+        viewController.saveClicked()
+
+        XCTAssertNotNil(UserDefaults.standard.object(forKey: UserDefaultsKey.showNetworkInterfaces))
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: UserDefaultsKey.showNetworkInterfaces))
+    }
+}


### PR DESCRIPTION
### What's new?
Refine the menu layout by reorganizing DNS controls, improving ping and loss presentation, and aligning top-level items with clearer styling. Add a preference to hide the network interfaces section while covering the new menu and preferences behavior with focused tests


I stumbled upon this package but thought it could use some UI/UX improvements to. The main focus is on 
1. making it easier to use
1. highlight what ultimately matters -> ping info

Before:
<img width="383" height="300" alt="Screenshot 2026-03-29 at 22 15 07" src="https://github.com/user-attachments/assets/9c9ee13c-2375-4546-b92e-a44ed753ac2c" />

After (with network interfaces showing):
<img width="409" height="274" alt="Screenshot 2026-03-29 at 22 19 53" src="https://github.com/user-attachments/assets/2d328272-cfa4-4e37-9cd9-9db2deb7acdc" />

After (without network interfaces showing):
<img width="389" height="184" alt="Screenshot 2026-03-29 at 22 13 48" src="https://github.com/user-attachments/assets/05f5b821-df00-46a5-abd1-d37ec2aa9081" />

My suggestion would be to hide the network interfaces by default but it's your package after all.

Let me know what you think!
